### PR TITLE
Changes the way to get spiders list to avoid deprecation message

### DIFF
--- a/wsf_scraping/pipelines.py
+++ b/wsf_scraping/pipelines.py
@@ -28,12 +28,9 @@ class WsfScrapingPipeline(object):
 
         spider_loader = spiderloader.SpiderLoader.from_settings(self.settings)
         spiders = spider_loader.list()
-        if not os.path.isdir('./results/pdfs'):
-            os.makedirs('./results/pdfs')
 
         for spider_name in spiders:
-            if not os.path.isdir('./results/pdfs/%s' % spider_name):
-                os.makedirs('./results/pdfs/%s' % spider_name)
+            os.makedirs('./results/pdfs/%s' % spider_name, exist_ok=True)
 
     def process_item(self, item, spider):
         """Process items sent by the spider."""

--- a/wsf_scraping/pipelines.py
+++ b/wsf_scraping/pipelines.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 import os
 import logging
+from scrapy import spiderloader
+from scrapy.utils.project import get_project_settings
 from tools.dbTools import insert_article
 from tools.cleaners import parse_keywords_files
-from scrapy.utils.project import get_project_settings
 from pdf_parser.pdf_parse import (parse_pdf_document, grab_section,
                                   parse_pdf_document_pdftxt)
 
@@ -25,17 +26,14 @@ class WsfScrapingPipeline(object):
         self.logger = logging.getLogger(__name__)
         self.logger.setLevel(logging.INFO)
 
-    @classmethod
-    def from_crawler(cls, crawler):
-        spiders = crawler.spiders.list()
+        spider_loader = spiderloader.SpiderLoader.from_settings(self.settings)
+        spiders = spider_loader.list()
         if not os.path.isdir('./results/pdfs'):
             os.makedirs('./results/pdfs')
 
         for spider_name in spiders:
             if not os.path.isdir('./results/pdfs/%s' % spider_name):
                 os.makedirs('./results/pdfs/%s' % spider_name)
-
-        return cls()
 
     def process_item(self, item, spider):
         """Process items sent by the spider."""


### PR DESCRIPTION
Using Crawler.spider leads to the following deprecation message:
```
WARNING: /tmp/wsf_scraping-1519646027-ck0gl203.egg/wsf_scraping/pipelines.py:30: ScrapyDeprecationWarning: Crawler.spiders is deprecated, use CrawlerRunner.spider_loader or instantiate scrapy.spiderloader.SpiderLoader with your settings.
```

This pull requests changes Crawler.spider to the recommended spiderloader method.