### PR TITLE
 Changes the way to check for duplicates by using the file footprint

### DIFF
--- a/tests/test_db_tools.py
+++ b/tests/test_db_tools.py
@@ -1,0 +1,29 @@
+import unittest
+import sqlite3
+from tools import SQLite3Connector
+
+
+class TestDBTools(unittest.TestCase):
+
+    def setUp(self):
+        self.database = SQLite3Connector()
+
+    def test_queries(self):
+        self.database.insert_article(
+            'Test',
+            '0' * 32,
+            'http://example.com/pdf.pdf'
+        )
+        self.assertTrue(self.database.is_scraped('0' * 32))
+        self.database._execute(
+            'DELETE FROM article WHERE file_hash = ?',
+            ('0' * 32,)
+        )
+        self.assertFalse(self.database.is_scraped('0' * 32))
+
+    def test_exception(self):
+            self.assertRaises(
+                sqlite3.Error,
+                self.database._execute,
+                'SELECT 1 FROM sssss'
+            )

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,5 @@
+from .dbTools import SQLite3Connector
+from . import cleaners
+from .DSXFeedStorage import DSXFeedStorage
+
+__all__ = [SQLite3Connector, cleaners, DSXFeedStorage]

--- a/tools/cleaners.py
+++ b/tools/cleaners.py
@@ -37,8 +37,9 @@ def get_file_hash(file_path):
     BLOCKSIZE = 65536
     hasher = hashlib.md5()
     with open(file_path, 'rb') as f:
-        buf = f.read(BLOCKSIZE)
-        while len(buf) > 0:
-            hasher.update(buf)
+        while True:
             buf = f.read(BLOCKSIZE)
+            if not buf:
+                break
+            hasher.update(buf)
     return hasher.hexdigest()

--- a/tools/cleaners.py
+++ b/tools/cleaners.py
@@ -18,14 +18,14 @@ def parse_keywords_files(file_path):
     keywords_list = []
     try:
         with open(file_path, 'r') as f:
-            logger.debug("Successfully opened %s" % file_path)
+            logger.debug("Successfully opened %s", file_path)
             for line in f:
                 line = line.replace('\n', '')
                 if line and line[0] != '#':
                     keywords_list.append(line.lower())
     except IOError:
         logger.warning(
-            "Unable to open keywords file at location %s" % file_path
+            "Unable to open keywords file at location %s", file_path
         )
         keywords_list = []
     finally:

--- a/tools/cleaners.py
+++ b/tools/cleaners.py
@@ -1,5 +1,6 @@
 # # -*- coding: utf-8 -*-
 import re
+import hashlib
 import logging
 
 
@@ -29,3 +30,15 @@ def parse_keywords_files(file_path):
         keywords_list = []
     finally:
         return keywords_list
+
+
+def get_file_hash(file_path):
+    """Return the md5 hash of a file."""
+    BLOCKSIZE = 65536
+    hasher = hashlib.md5()
+    with open(file_path, 'rb') as f:
+        buf = f.read(BLOCKSIZE)
+        while len(buf) > 0:
+            hasher.update(buf)
+            buf = f.read(BLOCKSIZE)
+    return hasher.hexdigest()

--- a/tools/dbTools.py
+++ b/tools/dbTools.py
@@ -13,6 +13,7 @@ def check_db():
             id INTEGER PRIMARY KEY,
             title VARCHAR(64),
             url VARCHAR(255),
+            file_hash VARCHAR(255),
             scrap_again INTEGER(1) DEFAULT(0),
             Timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
         );
@@ -37,13 +38,27 @@ def is_scraped(url):
     return result if result else False
 
 
-def insert_article(title, url):
+def check_file(file_hash):
+        #  Init sqlite db to filter PDFs
+        connection = sqlite3.connect('db.sqlite3')
+        cursor = connection.cursor()
+
+        cursor.execute(
+            "SELECT id FROM article WHERE file_hash = ?",
+            (file_hash,)
+        )
+        result = cursor.fetchone()
+        connection.close()
+        return result if result else False
+
+
+def insert_article(title, file_hash, url):
     #  Init sqlite db to filter PDFs
     connection = sqlite3.connect('db.sqlite3')
     cursor = connection.cursor()
     cursor.execute(
-        "INSERT INTO article (title, url) VALUES (?, ?)",
-        (title, url)
+        "INSERT INTO article (title, file_hash, url) VALUES (?, ?, ?)",
+        (title, file_hash, url)
     )
 
     connection.commit()

--- a/tools/dbTools.py
+++ b/tools/dbTools.py
@@ -13,9 +13,9 @@ def check_db():
             id INTEGER PRIMARY KEY,
             title VARCHAR(64),
             url VARCHAR(255),
-            file_hash VARCHAR(255),
+            file_hash VARCHAR(32),
             scrap_again INTEGER(1) DEFAULT(0),
-            Timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
         );
         """
     )

--- a/tools/dbTools.py
+++ b/tools/dbTools.py
@@ -1,65 +1,54 @@
 import sqlite3
+import logging
 
 
-def check_db():
-    connection = sqlite3.connect('db.sqlite3')
-    cursor = connection.cursor()
+class SQLite3Connector:
+    def __init__(self):
+        self.logger = logging.getLogger(__name__)
+        self.connection = sqlite3.connect('db.sqlite3')
+        self.cursor = self.connection.cursor()
+        self._check_db()
 
-    # If articles table does not exist, create it
-    cursor.execute(
-        """
-        CREATE TABLE IF NOT EXISTS article
-        (
-            id INTEGER PRIMARY KEY,
-            title VARCHAR(64),
-            url VARCHAR(255),
-            file_hash VARCHAR(32),
-            scrap_again INTEGER(1) DEFAULT(0),
-            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
-        );
-        """
-    )
+    def __del__(self):
+        self.connection.commit()
+        self.cursor.close()
+        self.connection.close()
 
-    connection.commit()
-    connection.close()
+    def _execute(self, query, params=()):
+        try:
+            self.cursor.execute(query, params)
+        except Exception as error:
+            self.logger.error(
+                'An exception had been encountered when executing {}'.format(
+                    query,
+                )
+            )
 
+    def _check_db(self):
+        self._execute(
+            """
+            CREATE TABLE IF NOT EXISTS article
+            (
+                id INTEGER PRIMARY KEY,
+                title VARCHAR(64),
+                url VARCHAR(255),
+                file_hash VARCHAR(32),
+                scrap_again INTEGER(1) DEFAULT(0),
+                timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            );
+            """
+        )
 
-def is_scraped(url):
-    #  Init sqlite db to filter PDFs
-    connection = sqlite3.connect('db.sqlite3')
-    cursor = connection.cursor()
-
-    cursor.execute(
-        "SELECT id FROM article WHERE url LIKE ? AND scrap_again=0",
-        ('%' + url,)
-    )
-    result = cursor.fetchone()
-    connection.close()
-    return result if result else False
-
-
-def check_file(file_hash):
-        #  Init sqlite db to filter PDFs
-        connection = sqlite3.connect('db.sqlite3')
-        cursor = connection.cursor()
-
-        cursor.execute(
+    def is_scraped(self, file_hash):
+        self._execute(
             "SELECT id FROM article WHERE file_hash = ?",
             (file_hash,)
         )
-        result = cursor.fetchone()
-        connection.close()
-        return result if result else False
+        result = self.cursor.fetchone()
+        return result or None
 
-
-def insert_article(title, file_hash, url):
-    #  Init sqlite db to filter PDFs
-    connection = sqlite3.connect('db.sqlite3')
-    cursor = connection.cursor()
-    cursor.execute(
-        "INSERT INTO article (title, file_hash, url) VALUES (?, ?, ?)",
-        (title, file_hash, url)
-    )
-
-    connection.commit()
-    connection.close()
+    def insert_article(self, title, file_hash, url):
+        self._execute(
+            "INSERT INTO article (title, file_hash, url) VALUES (?, ?, ?)",
+            (title, file_hash, url)
+        )

--- a/tools/dbTools.py
+++ b/tools/dbTools.py
@@ -17,12 +17,12 @@ class SQLite3Connector:
     def _execute(self, query, params=()):
         try:
             self.cursor.execute(query, params)
-        except Exception as error:
+        except sqlite3.Error as error:
             self.logger.error(
-                'An exception had been encountered when executing {}'.format(
-                    query,
-                )
+                'An exception had been encountered when executing %s',
+                query,
             )
+            raise
 
     def _check_db(self):
         self._execute(

--- a/wsf_scraping/middlewares.py
+++ b/wsf_scraping/middlewares.py
@@ -1,6 +1,19 @@
 # -*- coding: utf-8 -*-
-
+import logging
 from scrapy import signals
+from scrapy import logformatter
+
+
+class PoliteLogFormatter(logformatter.LogFormatter):
+    def dropped(self, item, exception, response, spider):
+        return {
+            'level': logging.DEBUG,
+            'msg': logformatter.DROPPEDMSG,
+            'args': {
+                'exception': exception,
+                'item': item,
+            }
+        }
 
 
 class WsfScrapingSpiderMiddleware(object):

--- a/wsf_scraping/pipelines.py
+++ b/wsf_scraping/pipelines.py
@@ -48,7 +48,6 @@ class WsfScrapingPipeline(object):
             'results',
             'pdfs',
             spider_name,
-            '/'
         )
 
         # Convert PDF content to text format

--- a/wsf_scraping/pipelines.py
+++ b/wsf_scraping/pipelines.py
@@ -49,10 +49,11 @@ class WsfScrapingPipeline(object):
                 )
                 return item
 
-            self.logger.info('Processing: %s (%s)' % (
+            self.logger.info(
+                'Processing: %s (%s)',
                 item['pdf'],
                 self.settings['PARSING_METHOD'],
-            ))
+            )
 
             if self.settings['PARSING_METHOD'] == 'pdftotext':
                 pdf_file = parse_pdf_document_pdftxt(f)

--- a/wsf_scraping/settings.py
+++ b/wsf_scraping/settings.py
@@ -31,10 +31,11 @@ FEED_STORAGES = {
 
 # LOG_ENABLED = False
 LOG_LEVEL = 'INFO'
+LOG_FORMATTER = 'wsf_scraping.middlewares.PoliteLogFormatter'
 LOG_FILE = 'var/log-{log_level}.txt'.format(log_level=LOG_LEVEL)
 # Set pdfminer log to WARNING
 logging.getLogger("pdfminer").setLevel(logging.WARNING)
-
+DUPEFILTER_CLASS = 'scrapy.dupefilters.BaseDupeFilter'
 # Use a physicqal queue, slower but add fiability
 DEPTH_PRIORITY = 1
 SCHEDULER_DISK_QUEUE = 'scrapy.squeues.PickleFifoDiskQueue'

--- a/wsf_scraping/settings.py
+++ b/wsf_scraping/settings.py
@@ -26,7 +26,7 @@ ITEM_PIPELINES = {
     'wsf_scraping.pipelines.WsfScrapingPipeline': 10,
 }
 FEED_STORAGES = {
-    'dsx': 'tools.DSXFeedStorage.DSXFeedStorage',
+    'dsx': 'tools.DSXFeedStorage',
 }
 
 # LOG_ENABLED = False

--- a/wsf_scraping/spiders/nice_spider.py
+++ b/wsf_scraping/spiders/nice_spider.py
@@ -48,14 +48,13 @@ class NiceSpider(scrapy.Spider):
             'referer': 'https://www.nice.org.uk/guidance/published'
         }
 
-        self.logger.info('Initial url: %s' % url)
+        self.logger.info('Initial url: %s', url)
         yield scrapy.Request(
             url=url,
             headers=headers,
             errback=self.on_error,
             dont_filter=True,
             callback=self.parse,
-            dont_filter=True
         )
 
     def parse(self, response):
@@ -175,8 +174,8 @@ class NiceSpider(scrapy.Spider):
 
         else:
             self.logger.info(
-                'No link found to download the pdf version (%s)'
-                % response.request.url
+                'No link found to download the pdf version (%s)',
+                response.request.url
             )
 
     def save_pdf(self, response):
@@ -193,7 +192,7 @@ class NiceSpider(scrapy.Spider):
         is_pdf = response.headers.get('content-type', '') == b'application/pdf'
 
         if not is_pdf:
-            self.logger.info('Not a PDF, aborting (%s)' % response.url)
+            self.logger.info('Not a PDF, aborting (%s)', response.url)
             return
 
         filename = ''.join([response.url.split('/')[-1], '.pdf'])

--- a/wsf_scraping/spiders/nice_spider.py
+++ b/wsf_scraping/spiders/nice_spider.py
@@ -3,7 +3,6 @@ import scrapy
 from lxml import html
 from scrapy.http import Request
 from wsf_scraping.items import NICEArticle
-from tools.dbTools import is_scraped, check_db
 from scrapy.spidermiddlewares.httperror import HttpError
 from twisted.internet.error import DNSLookupError
 from twisted.internet.error import TimeoutError
@@ -12,9 +11,9 @@ from twisted.internet.error import TimeoutError
 class NiceSpider(scrapy.Spider):
     name = 'nice'
 
-    # custom_settings = {
-    #     'JOBDIR': 'crawls/nice'
-    # }
+    custom_settings = {
+        'JOBDIR': 'crawls/nice'
+    }
 
     def on_error(self, failure):
         self.logger.error(repr(failure))
@@ -33,9 +32,6 @@ class NiceSpider(scrapy.Spider):
 
     def start_requests(self):
         """Set up the initial request to the website to scrape."""
-
-        # Check that the database is set up with the correct columns
-        check_db()
 
         articles_count = self.settings['NICE_ARTICLES_COUNT']
 
@@ -59,6 +55,7 @@ class NiceSpider(scrapy.Spider):
             errback=self.on_error,
             dont_filter=True,
             callback=self.parse,
+            dont_filter=True
         )
 
     def parse(self, response):
@@ -194,13 +191,6 @@ class NiceSpider(scrapy.Spider):
 
         # Download PDF file to /tmp
         is_pdf = response.headers.get('content-type', '') == b'application/pdf'
-
-        if is_scraped(response.request.url):
-            self.logger.debug(
-                "Item already Dowmloaded or null - Canceling (%s)"
-                % response.request.url
-            )
-            return
 
         if not is_pdf:
             self.logger.info('Not a PDF, aborting (%s)' % response.url)

--- a/wsf_scraping/spiders/who_iris_spider.py
+++ b/wsf_scraping/spiders/who_iris_spider.py
@@ -1,7 +1,6 @@
 import scrapy
 from scrapy.http import Request
 from tools.cleaners import clean_html
-from tools.dbTools import is_scraped, check_db
 from wsf_scraping.items import WHOArticle
 from scrapy.utils.project import get_project_settings
 from scrapy.spidermiddlewares.httperror import HttpError
@@ -52,9 +51,6 @@ class WhoIrisSpider(scrapy.Spider):
     def start_requests(self):
         """ This sets up the urls to scrape for each years.
         """
-
-        # Check that the database is set up with the correct columns
-        check_db()
 
         self.data['rpp'] = self.settings['WHO_IRIS_RPP']
         urls = []
@@ -134,7 +130,7 @@ class WhoIrisSpider(scrapy.Spider):
 
         # Scrap all the pdf on the page, passing scrapped metadata
         href = response.css('a[href$=".pdf"]::attr(href)').extract_first()
-        if href and not is_scraped(href.split('/')[-1]):
+        if href:
             yield Request(
                 url=response.urljoin(href),
                 callback=self.save_pdf,
@@ -144,7 +140,7 @@ class WhoIrisSpider(scrapy.Spider):
         else:
             err_link = href if href else ''.join([response.url, ' (referer)'])
             self.logger.debug(
-                "Item already Downloaded or null - Canceling (%s)"
+                "Item is null - Canceling (%s)"
                 % err_link
             )
 

--- a/wsf_scraping/spiders/who_iris_spider.py
+++ b/wsf_scraping/spiders/who_iris_spider.py
@@ -68,7 +68,7 @@ class WhoIrisSpider(scrapy.Spider):
             urls.append((url.format(**self.data), year))
 
         for url in urls:
-            self.logger.info(url[0])
+            self.logger.info('Initial url: %s', url[0])
             yield scrapy.Request(
                 url=url[0],
                 callback=self.parse,
@@ -140,8 +140,8 @@ class WhoIrisSpider(scrapy.Spider):
         else:
             err_link = href if href else ''.join([response.url, ' (referer)'])
             self.logger.debug(
-                "Item is null - Canceling (%s)"
-                % err_link
+                "Item is null - Canceling (%s)",
+                err_link
             )
 
     def save_pdf(self, response):
@@ -155,7 +155,7 @@ class WhoIrisSpider(scrapy.Spider):
         is_pdf = response.headers.get('content-type', '') == b'application/pdf'
 
         if not is_pdf:
-            self.logger.info('Not a PDF, aborting (%s)' % response.url)
+            self.logger.info('Not a PDF, aborting (%s)', response.url)
             return
 
         # Retrieve metadata


### PR DESCRIPTION
Instead of using the file name in the url, rely on the file footprint.

It will help to look for changes in already scraped files, and will allow us to reduce the number of duplicates, as some files have a slightly different name but the exact same content on the Who IRIS website.

Also include a bit of cleaning on the NICE spider (custom crawl dir shouldn't be commented and add a "dont_filter" to the initial request).