### PR TITLE
Modify the web scrapper in order to make it works with the new AWS architecture

### DIFF
--- a/Dockerfile-periodic
+++ b/Dockerfile-periodic
@@ -31,10 +31,8 @@ COPY ./scrapy.cfg /wsf_scraper/scrapy.cfg
 COPY ./requirements-periodic-scraping.txt /wsf_scraper/requirements.txt
 
 # Scrapy needs a var directory to store logs
-RUN mkdir var
-
+RUN mkdir -p var/tmp
+RUN pip install -U pip
 RUN pip install -r requirements.txt
-
-EXPOSE 5005
 
 CMD ["./entrypoint.sh"]

--- a/Dockerfile-periodic
+++ b/Dockerfile-periodic
@@ -1,0 +1,40 @@
+# Use a basic Python image
+FROM python:3.6.4
+
+# Poppler is needed to run pdftotext convertion
+RUN apt-get update -yqq \
+  && apt-get install -yqq --no-install-recommends \
+    gcc \
+    libpoppler-cpp-dev \
+    poppler-utils \
+    pkg-config \
+    locales \
+  && apt-get -q clean
+
+# Build locales to avoid encoding issues with Scrapy encoding
+RUN locale-gen en_GB.UTF-8
+
+ENV LC_ALL=en_GB.UTF-8
+ENV LANG=en_GB.UTF-8
+ENV LANGUAGE=en_GB.UTF-8
+
+WORKDIR /wsf_scraper
+
+COPY ./wsf_scraping /wsf_scraper/wsf_scraping
+COPY ./resources /wsf_scraper/resources
+COPY ./pdf_parser /wsf_scraper/pdf_parser
+COPY ./tools /wsf_scraper/tools
+
+COPY ./entrypoint.sh /wsf_scraper/entrypoint.sh
+
+COPY ./scrapy.cfg /wsf_scraper/scrapy.cfg
+COPY ./requirements-periodic-scraping.txt /wsf_scraper/requirements.txt
+
+# Scrapy needs a var directory to store logs
+RUN mkdir var
+
+RUN pip install -r requirements.txt
+
+EXPOSE 5005
+
+CMD ["./entrypoint.sh"]

--- a/docker-compose-periodic.yml
+++ b/docker-compose-periodic.yml
@@ -1,0 +1,25 @@
+version: '3.4'
+services:
+  web:
+    container_name: scrAPI
+    build:
+        context: .
+        dockerfile: Dockerfile-periodic
+    ports:
+      - 5005:5005
+    env_file:
+      - web_variables-dev.env
+    depends_on:
+      - articles-db
+    links:
+      - articles-db
+
+  articles-db:
+    container_name: articles-db
+    build:
+      context: ./db
+      dockerfile: Dockerfile
+    ports:
+      - 5436:5432
+    env_file:
+      - db_variables.env

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,14 +3,7 @@
 set -o nounset
 set -o errexit
 
-if [ "$SPIDER_TO_RUN" == 'who_iris' ]
-then
-    scrapy crawl who_iris
-elif [ "$SPIDER_TO_RUN" == 'nice' ]
-then
-    scrapy crawl nice
-else
-    echo "Either you did not specifiy a spider, or the spider you want to run does not exist."
-    exit 1
-fi
+echo "Running $SPIDER_TO_RUN spider."
+scrapy crawl "$SPIDER_TO_RUN"
+
 exit 0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,7 @@ elif [ "$SPIDER_TO_RUN" == 'nice' ]
 then
     scrapy crawl nice
 else
+    echo "Either you did not specified a spider, or the spider you want to run does not exists."
     exit 1
 fi
 exit 0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+
+if [ "$SPIDER_TO_RUN" == 'who_iris' ]
+then
+    scrapy crawl who_iris
+elif [ "$SPIDER_TO_RUN" == 'nice' ]
+then
+    scrapy crawl nice
+else
+    exit 1
+fi
+exit 0

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ elif [ "$SPIDER_TO_RUN" == 'nice' ]
 then
     scrapy crawl nice
 else
-    echo "Either you did not specified a spider, or the spider you want to run does not exists."
+    echo "Either you did not specifiy a spider, or the spider you want to run does not exist."
     exit 1
 fi
 exit 0

--- a/requirements-periodic-scraping.txt
+++ b/requirements-periodic-scraping.txt
@@ -1,0 +1,10 @@
+attrs==17.3.0
+beautifulsoup4==4.6.0
+botocore==1.8.11
+bs4==0.0.1
+lxml==4.1.1
+pdfminer.six==20170720
+psycopg2-binary==2.7.4
+pyahocorasick==1.1.6
+requests==2.18.4
+Scrapy==1.4.0

--- a/requirements-periodic-scraping.txt
+++ b/requirements-periodic-scraping.txt
@@ -1,6 +1,6 @@
 attrs==17.3.0
 beautifulsoup4==4.6.0
-botocore==1.8.11
+boto3==1.7.4
 bs4==0.0.1
 lxml==4.1.1
 pdfminer.six==20170720

--- a/tests/test_db_tools.py
+++ b/tests/test_db_tools.py
@@ -10,7 +10,6 @@ class TestDBTools(unittest.TestCase):
 
     def test_queries(self):
         self.database.insert_article(
-            'Test',
             '0' * 32,
             'http://example.com/pdf.pdf'
         )

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -1,0 +1,92 @@
+import unittest
+import boto3
+from moto import mock_dynamodb2
+from tools import DynamoDBConnector
+
+
+@mock_dynamodb2
+class TestScraperArticles(unittest.TestCase):
+    """Test dynamodb scraper_articles related methods from the
+    DynamoDBConnector module.
+    """
+    def setUp(self):
+        """Initialise the dynamodb connector and create a mock table."""
+        self.dynamodb = DynamoDBConnector('us-east-1')
+        client = boto3.client('dynamodb', region_name='us-east-1')
+        client.create_table(
+            AttributeDefinitions=[
+                {
+                    'AttributeName': 'file_hash',
+                    'AttributeType': 'S'
+                },
+            ],
+            TableName='scraper_articles',
+            KeySchema=[
+                {
+                    'AttributeName': 'file_hash',
+                    'KeyType': 'HASH'
+                },
+            ],
+            ProvisionedThroughput={
+                'ReadCapacityUnits': 1,
+                'WriteCapacityUnits': 1
+            },
+        )
+
+    def test_insert_dynamo_article(self):
+        """Check if the is_scraped and the insert_article methods are working
+        properly.
+        """
+        self.assertFalse(self.dynamodb.is_scraped('00'))
+        self.dynamodb.insert_article('0' * 32, 'http://foo.bar')
+        self.assertTrue(self.dynamodb.is_scraped('0' * 32))
+
+
+@mock_dynamodb2
+class TestsScraperCatalog(unittest.TestCase):
+    """Test dynamodb scraper_catalog related methods from the
+    DynamoDBConnector module.
+    """
+    def setUp(self):
+        """Initialise the dynamodb connector and create a mock table."""
+        self.dynamodb = DynamoDBConnector('us-east-1')
+        client = boto3.client('dynamodb', region_name='us-east-1')
+        client.create_table(
+            AttributeDefinitions=[
+                {
+                    'AttributeName': 'file_index',
+                    'AttributeType': 'S'
+                },
+            ],
+            TableName='scraper_catalog',
+            KeySchema=[
+                {
+                    'AttributeName': 'file_index',
+                    'KeyType': 'HASH'
+                },
+            ],
+            ProvisionedThroughput={
+                'ReadCapacityUnits': 1,
+                'WriteCapacityUnits': 1
+            },
+        )
+
+    def test_insert_file_in_catalog(self):
+        """Check if the insert_file_in_catalog method is working."""
+        client = boto3.client('dynamodb', region_name='us-east-1')
+        item = client.get_item(
+            TableName='scraper_catalog',
+            Key={
+                'file_index': {'S': 'foo'},
+            },
+            ConsistentRead=True,
+        )
+        self.assertFalse('Item' in item.keys())
+        self.dynamodb.insert_file_in_catalog('index', '/foo/bar')
+        item = client.get_item(
+            TableName='scraper_catalog',
+            Key={
+                'file_index': {'S': 'index'},
+            },
+            ConsistentRead=True,
+        )

--- a/tools/dynamodbConnector.py
+++ b/tools/dynamodbConnector.py
@@ -14,8 +14,6 @@ class DynamoDBConnector:
         self.logger = logging.getLogger(__name__)
         self.dynamodb = boto3.resource(
             'dynamodb',
-            region_name='eu-west-2',
-            endpoint_url='http://localhost:8765'
         )
         try:
             if 'scraper_articles' not in self.dynamodb.tables.all():
@@ -49,7 +47,7 @@ class DynamoDBConnector:
             response = table.put_item(Item={
                 'file_index': file_index,
                 'file_path': file_path,
-                'date_created': datetime.now()
+                'date_created': str(datetime.now())
             })
         except ClientError as e:
             self.logger.error('Couldn\'t insert file in the catalog [%s]', e)

--- a/wsf_scraping/pipelines.py
+++ b/wsf_scraping/pipelines.py
@@ -116,7 +116,12 @@ class WsfScrapingPipeline(object):
                     os.path.join(pdf_result_path, item['pdf'])
                 )
         else:
-            os.remove(base_pdf_path)
+            try:
+                os.remove(base_pdf_path)
+            except FileNotFoundError:
+                self.logger.warning(
+                    "The file couldn't be found, and wasn't deleted."
+                )
         return item
 
     def process_item(self, item, spider):

--- a/wsf_scraping/settings.py
+++ b/wsf_scraping/settings.py
@@ -23,7 +23,7 @@ FEED_STORAGES = {
 # LOG_ENABLED = False
 LOG_LEVEL = 'INFO'
 LOG_FORMATTER = 'wsf_scraping.middlewares.PoliteLogFormatter'
-LOG_FILE = 'var/log-{log_level}.txt'.format(log_level=LOG_LEVEL)
+# LOG_FILE = 'var/log-{log_level}.txt'.format(log_level=LOG_LEVEL)
 # Set pdfminer log to WARNING
 logging.getLogger("pdfminer").setLevel(logging.WARNING)
 DUPEFILTER_CLASS = 'scrapy.dupefilters.BaseDupeFilter'
@@ -80,10 +80,13 @@ FEED_EXPORT_ENCODING = 'utf-8'
 FEED_TEMPDIR = 'var/tmp/'
 
 if FEED_CONFIG == 'AWS':
-    AWS_S3_BUCKET = 'data-labs'
+    AWS_S3_BUCKET = 'data-labs-data'
     AWS_S3_FILE_NAME = 'scraper-results/%(name)s - %(time)s.json'
     DATABASE_ADAPTOR = 'dynamodb'
-    FEED_URI = f'aws://{AWS_S3_BUCKET}/{AWS_S3_FILE_NAME}'
+    FEED_URI = 'aws://{bucket}/{filename}'.format(
+        bucket=AWS_S3_BUCKET,
+        filename=AWS_S3_FILE_NAME
+    )
 
 else:
     # By default, log the results in a local folder

--- a/wsf_scraping/settings.py
+++ b/wsf_scraping/settings.py
@@ -81,7 +81,7 @@ FEED_TEMPDIR = 'var/tmp/'
 
 if FEED_CONFIG == 'AWS':
     AWS_S3_BUCKET = 'data-labs-data'
-    AWS_S3_FILE_NAME = 'scraper-results/%(name)s - %(time)s.json'
+    AWS_S3_FILE_NAME = 'scraper-results/%(name)s'
     DATABASE_ADAPTOR = 'dynamodb'
     FEED_URI = 'aws://{bucket}/{filename}'.format(
         bucket=AWS_S3_BUCKET,

--- a/wsf_scraping/settings.py
+++ b/wsf_scraping/settings.py
@@ -20,12 +20,12 @@ FEED_STORAGES = {
     'aws': 'tools.AWSFeedStorage',
 }
 
-# LOG_ENABLED = False
 LOG_LEVEL = 'INFO'
 LOG_FORMATTER = 'wsf_scraping.middlewares.PoliteLogFormatter'
-# LOG_FILE = 'var/log-{log_level}.txt'.format(log_level=LOG_LEVEL)
+
 # Set pdfminer log to WARNING
 logging.getLogger("pdfminer").setLevel(logging.WARNING)
+
 DUPEFILTER_CLASS = 'scrapy.dupefilters.BaseDupeFilter'
 # Use a physicqal queue, slower but add fiability
 DEPTH_PRIORITY = 1
@@ -80,7 +80,7 @@ FEED_EXPORT_ENCODING = 'utf-8'
 FEED_TEMPDIR = 'var/tmp/'
 
 if FEED_CONFIG == 'AWS':
-    AWS_S3_BUCKET = 'data-labs-data'
+    AWS_S3_BUCKET = 'datalabs-data'
     AWS_S3_FILE_NAME = 'scraper-results/%(name)s'
     DATABASE_ADAPTOR = 'dynamodb'
     FEED_URI = 'aws://{bucket}/{filename}'.format(

--- a/wsf_scraping/spiders/who_iris_spider.py
+++ b/wsf_scraping/spiders/who_iris_spider.py
@@ -103,18 +103,18 @@ class WhoIrisSpider(scrapy.Spider):
             )
 
         if not self.settings['WHO_IRIS_LIMIT']:
-            # Follow next link
+            # Follow next link if it exists and if we enabled it
             next_page = response.css(
-                 'next-page-link::attr("href")'
+                 '.next-page-link::attr("href")'
             ).extract_first()
-
-            yield Request(
-                url=response.urljoin(next_page),
-                callback=self.parse,
-                errback=self.on_error,
-                dont_filter=True,
-                meta={'year': year}
-            )
+            if next_page:
+                yield Request(
+                    url=response.urljoin(next_page),
+                    callback=self.parse,
+                    errback=self.on_error,
+                    dont_filter=True,
+                    meta={'year': year}
+                )
 
     def parse_article(self, response):
         """ Scrape the article metadata from the detailed article page. Then,


### PR DESCRIPTION
This pull request add a "periodic running" mode to the web scraper, to make it compatible with the new AWS architecture. These changes include:
 - Specific Dockerfile and requirements
 - DynamoDB full compatibility
 - Export results to S3 and write path to a dynamodb catalog
 - Minor fixes and improvements

The weird way to merge file contents in `AWSFeedStorage._store_in_thread` mostly comes from the strange way scrapy has to pass the `data_file` (a custom tempfile).

The LOG_FILE setting has been commented in order to be able to access logs in cloudwatch.