### PR TITLE
Parametered launch of scrapy

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,23 @@
 #!/bin/bash
 
-set -o nounset
 set -o errexit
 
-echo "Running $SPIDER_TO_RUN spider."
-scrapy crawl "$SPIDER_TO_RUN"
+if [[ -z "$SCRAPY_YEARS" ]]; then
+  YEARS_LIST=''
+else
+  YEARS_LIST="-a years_list=\"$SCRAPY_YEARS\""
+fi
+if [[ -z "$SCRAPY_OPTIONS" ]]; then
+    OPTIONS_LIST=''
+else
+    OPTIONS_LIST=$SCRAPY_OPTIONS
+fi
+if [[ -z "$SPIDER_TO_RUN" ]]; then
+    echo "Either you did not specify a spider, or the spider you want to run does not exist."
+    exit 1
+fi
+
+echo "Running scrapy crawl $SPIDER_TO_RUN $YEARS_LIST $OPTIONS_LIST"
+scrapy crawl "$SPIDER_TO_RUN" $YEARS_LIST $OPTIONS_LIST
 
 exit 0


### PR DESCRIPTION
This PR aims to let us launch the webscraper with some parameters. It'll try to access `SCRAPY_YEARS` and `SCRAPY_OPTIONS` environment variables, and if they're not empty, will add there content as scrapy commend parameters.

The quotes around the scrapy command have been removed on purpose for scrapy identified everything as a spider name instead of a group made of spider name, arguments and options.

The `set -o nounset` has been removed on purpose as well, as we may want some environment variables to be empty. 