### PR TITLE
Add gov.uk to the scraping list

### DIFF
--- a/pdf_parser/pdf_parse.py
+++ b/pdf_parser/pdf_parse.py
@@ -28,10 +28,11 @@ def parse_pdf_document(document):
         with open(os.devnull, 'w') as FNULL:
             subprocess.check_call(cmd, stdout=FNULL)
     except subprocess.CalledProcessError as e:
+        err = e.sdterr if e.stderr else ''
         logger.warning(
             "The pdf [%s] could not be converted: %s",
             document.name,
-            e.sdterr,
+            err,
         )
         return None
 

--- a/pdf_parser/pdf_parse.py
+++ b/pdf_parser/pdf_parse.py
@@ -3,110 +3,13 @@ import os
 import subprocess
 import logging
 from bs4 import BeautifulSoup as bs
-from pdfminer.pdfpage import PDFPage
-from pdfminer.pdfinterp import PDFResourceManager
-from pdfminer.pdfinterp import PDFPageInterpreter
-from pdfminer.converter import PDFPageAggregator
 from .objects.PdfObjects import PdfFile, PdfPage, PdfLine
 from .tools.extraction import _find_elements
-from pdfminer.layout import (LAParams, LTTextBox, LTTextLine, LTChar, LTAnno,
-                             LTTextBoxHorizontal, LTTextLineHorizontal)
 
 BASE_FONT_SIZE = -10
 
 
-TEXT_ELEMENTS = [
-    LTTextBox,
-    LTTextBoxHorizontal,
-    LTTextLine,
-    LTTextLineHorizontal
-]
-
-
-class PDFTextPageAggregator(PDFPageAggregator):
-    """As we don't need schemas and pictures, just don't render them."""
-
-    def render_image(self, name, stream):
-        return
-
-    def paint_path(self, gstate, stroke, fill, evenodd, path):
-        return
-
-
-def get_line_infos(txt_obj):
-    if isinstance(txt_obj, LTChar):
-        if 'bold' in txt_obj.fontname.lower():
-            return txt_obj.size, True, txt_obj.fontname
-        else:
-            return txt_obj.size, False, txt_obj.fontname
-    else:
-        # Reject Annotations
-        if not isinstance(txt_obj, LTAnno):
-            for char_obj in txt_obj:
-                return get_line_infos(char_obj)
-        # If no LTChar object is found, return the BASE_FONT_SIZE and False
-        return BASE_FONT_SIZE, False, None
-
-
-def parse_pdf_document(pdffile):
-    """ Given a path to a pdf, parse the file to return a PdfFile
-    object, easier to analyse.
-    """
-    pdf_pages = []
-    # Create all PDF resources needed by pdfminer.
-    rsrcmgr = PDFResourceManager()
-    laparams = LAParams(detect_vertical=True)
-    device = PDFTextPageAggregator(rsrcmgr, laparams=laparams)
-    # device = PDFTextPageAggregator(rsrcmgr)
-    interpreter = PDFPageInterpreter(rsrcmgr, device)
-    pages = PDFPage.get_pages(
-        pdffile,
-        set(),
-        caching=True,
-        check_extractable=True
-    )
-    for page_num, page in enumerate(pages):
-        pdf_lines = []
-        has_bold = False
-
-        # Process the page layout with pdfminer
-        interpreter.process_page(page)
-        layout = device.get_result()
-
-        # Retrieve layouts objects
-        for lt_obj in layout._objs:
-            if type(lt_obj) in TEXT_ELEMENTS:
-                # If the layout object contains text, iterate through its lines
-                for txt_obj in lt_obj._objs:
-                    # Retrieve informations (size, font face and bold)
-                    font_size, bold, font_face = get_line_infos(txt_obj)
-
-                    # We want bold lines to weight more to identofy titles
-                    if bold:
-                        has_bold = True
-                        font_size += 1
-                    else:
-                        font_size -= 1
-
-                    # Create a new PdfLine object and add it to the lines list
-                    pdf_line = PdfLine(
-                        int(math.ceil(font_size)),
-                        bold,
-                        txt_obj.get_text().strip(),
-                        page_num,
-                        font_face
-                    )
-                    pdf_lines.append(pdf_line)
-
-        # Add a new PdfPage object containing the lines to the pages list
-        pdf_pages.append(PdfPage(pdf_lines, page_num))
-
-    # Create a new PdfFile with the pages
-    pdf_file = PdfFile(pdf_pages, has_bold)
-    return pdf_file
-
-
-def parse_pdf_document_pdftxt(document):
+def parse_pdf_document(document):
     """ Given a path to a pdf, parse the file using pdftotext, to return a
     PdfFile object, easier to analyse.
     """

--- a/wsf_scraping/items.py
+++ b/wsf_scraping/items.py
@@ -29,3 +29,7 @@ class UNICEFArticle(BaseArticle):
 
 class MSFArticle(BaseArticle):
     pass
+
+
+class GovArticle(BaseArticle):
+    pass

--- a/wsf_scraping/pipelines.py
+++ b/wsf_scraping/pipelines.py
@@ -7,8 +7,7 @@ from tools import DatabaseConnector, DynamoDBConnector
 from tools.utils import parse_keywords_files, get_file_hash
 from scrapy.utils.project import get_project_settings
 from scrapy.exceptions import DropItem
-from pdf_parser.pdf_parse import (parse_pdf_document, grab_section,
-                                  parse_pdf_document_pdftxt)
+from pdf_parser.pdf_parse import parse_pdf_document, grab_section
 
 
 class WsfScrapingPipeline(object):
@@ -71,15 +70,11 @@ class WsfScrapingPipeline(object):
                 return item
 
             self.logger.info(
-                'Processing: %s (%s)',
-                item['pdf'],
-                self.settings['PARSING_METHOD'],
+                'Processing: %s',
+                item['pdf']
             )
 
-            if self.settings['PARSING_METHOD'] == 'pdftotext':
-                pdf_file = parse_pdf_document_pdftxt(f)
-            else:
-                pdf_file = parse_pdf_document(f)
+            pdf_file = parse_pdf_document(f)
 
             if not pdf_file:
                 return item

--- a/wsf_scraping/spiders/base_spider.py
+++ b/wsf_scraping/spiders/base_spider.py
@@ -25,6 +25,7 @@ class BaseSpider(scrapy.Spider):
             request = failure.request
             self.logger.error('TimeoutError on %s', request.url)
 
-    def _check_headers(self, response_headers):
+    def _check_headers(self, response_headers,
+                       desired_extension=b'application/pdf'):
         content_type = response_headers.get('content-type', '').split(b';')[0]
-        return b'application/pdf' == content_type
+        return desired_extension == content_type

--- a/wsf_scraping/spiders/gov_spider.py
+++ b/wsf_scraping/spiders/gov_spider.py
@@ -1,0 +1,160 @@
+import scrapy
+from urllib.parse import urlparse
+from scrapy.http import Request
+from collections import defaultdict
+from wsf_scraping.items import WHOArticle
+from scrapy.spidermiddlewares.httperror import HttpError
+from twisted.internet.error import DNSLookupError
+from twisted.internet.error import TimeoutError
+
+
+class GovSpider(scrapy.Spider):
+    name = 'gov_uk'
+
+    custom_settings = {
+        'JOBDIR': 'crawls/gov_uk'
+    }
+
+    def on_error(self, failure):
+        self.logger.error(repr(failure))
+
+        if failure.check(HttpError):
+            response = failure.value.response
+            self.logger.error(
+                'HttpError on %s (%s)',
+                response.url,
+                response.status,
+            )
+
+        elif failure.check(DNSLookupError):
+            request = failure.request
+            self.logger.error('DNSLookupError on %s', request.url)
+
+        elif failure.check(TimeoutError):
+            request = failure.request
+            self.logger.error('TimeoutError on %s', request.url)
+
+    def start_requests(self):
+        """ This sets up the urls to scrape for each years.
+        """
+
+        urls = [
+            'https://www.gov.uk/government/policies',
+        ]
+
+        for url in urls:
+            self.logger.info('Initial url: %s', url)
+            yield scrapy.Request(
+                url=url,
+                callback=self.parse,
+                errback=self.on_error,
+                dont_filter=True,
+            )
+
+    def parse(self, response):
+        """ Parse the articles listing page and go to the next one.
+
+        @url https://www.gov.uk/government/policies
+        @returns items 0 0
+        @returns requests 1
+        """
+
+        for href in response.css('.artifact-title a::attr(href)').extract():
+            full_records_link = ''.join([href, '?show=full'])
+            yield Request(
+                url=response.urljoin(full_records_link),
+                callback=self.parse_article,
+                errback=self.on_error,
+            )
+
+    def parse_article(self, response):
+        """ Scrape the article metadata from the detailed article page. Then,
+        redirect to the PDF page.
+
+        @url http://apps.who.int/iris/handle/10665/272346?show=full
+        @returns requests 1 1
+        @returns items 0 0
+        """
+
+        data_dict = {
+            'year': response.meta.get('year', {}),
+        }
+        data_dict['title'] = response.css(
+            'h2.page-header::text'
+        ).extract_first()
+
+        details_dict = defaultdict(list)
+        for line in response.css('.detailtable tr'):
+
+            # Each tr should have 2 to 3 td: attribute, value and language.
+            # We're only interested in the first and the second one.
+            tds = line.css('td::text').extract()
+            if len(tds) < 2:
+                continue
+
+            # Make attribute human readable
+            # (first part is always 'dc', so skip it)
+            attr_name = ' '.join(tds[0].split('.')[1:]).lower()
+            details_dict[attr_name].append(f'{tds[1]}')
+
+        # Scrap all the pdf on the page, passing scrapped metadata
+        href = response.css(
+            '.file-link a::attr("href")'
+        ).extract_first()
+
+        data_dict['subjects'] = details_dict.get('subject mesh', [])
+        data_dict['types'] = details_dict.get('type', [])
+        data_dict['authors'] = ', '.join(
+            details_dict.get('contributor author', [])
+        )
+        if href:
+            yield Request(
+                url=response.urljoin(href),
+                callback=self.save_pdf,
+                errback=self.on_error,
+                meta={'data_dict': data_dict}
+            )
+        else:
+            err_link = href if href else ''.join([response.url, ' (referer)'])
+            self.logger.debug(
+                "Item is null - Canceling (%s)",
+                err_link
+            )
+
+    def save_pdf(self, response):
+        """ Retrieve the pdf file and scan it to scrape keywords and sections.
+
+        @url http://apps.who.int/iris/bitstream/10665/123575/1/em_rc8_5_en.pdf
+        @returns items 1 1
+        @returns requests 0 0
+        """
+
+        content_type = response.headers.get('content-type', '').split(b';')[0]
+        is_pdf = b'application/pdf' == content_type
+
+        if not is_pdf:
+            self.logger.info('Not a PDF, aborting (%s)', response.url)
+            return
+
+        # Retrieve metadata
+        data_dict = response.meta.get('data_dict', {})
+        # Download PDF file to /tmp
+        filename = urlparse(response.url).path.split('/')[-1]
+        with open('/tmp/' + filename, 'wb') as f:
+            f.write(response.body)
+
+        # Populate a WHOArticle Item
+        who_article = WHOArticle({
+                'title': data_dict.get('title', ''),
+                'uri': response.request.url,
+                'year': data_dict.get('year', ''),
+                'authors': data_dict.get('authors', ''),
+                'types': data_dict.get('types'),
+                'subjects': data_dict.get('subjects'),
+                'pdf': filename,
+                'sections': {},
+                'keywords': {}
+            }
+        )
+
+        yield who_article

--- a/wsf_scraping/spiders/gov_spider.py
+++ b/wsf_scraping/spiders/gov_spider.py
@@ -29,7 +29,7 @@ class GovSpider(BaseSpider):
     def parse(self, response):
         """ Parse the articles listing page and go to the next one.
 
-        @url https://www.gov.uk/government/policies
+        @url https://www.gov.uk/government/publications
         @returns items 0 0
         @returns requests 1
         """
@@ -68,6 +68,8 @@ class GovSpider(BaseSpider):
             )
 
     def save_pdf(self, response):
+        """ Retrieve the pdf file and scan it to scrape keywords and sections.
+        """
         is_pdf = self._check_headers(response.headers)
 
         if not is_pdf:

--- a/wsf_scraping/spiders/gov_spider.py
+++ b/wsf_scraping/spiders/gov_spider.py
@@ -1,43 +1,18 @@
 import scrapy
 from urllib.parse import urlparse
 from scrapy.http import Request
-from collections import defaultdict
-from wsf_scraping.items import WHOArticle
-from scrapy.spidermiddlewares.httperror import HttpError
-from twisted.internet.error import DNSLookupError
-from twisted.internet.error import TimeoutError
+from .base_spider import BaseSpider
+from wsf_scraping.items import UNICEFArticle
 
 
-class GovSpider(scrapy.Spider):
+class GovSpider(BaseSpider):
     name = 'gov_uk'
-
     custom_settings = {
         'JOBDIR': 'crawls/gov_uk'
     }
 
-    def on_error(self, failure):
-        self.logger.error(repr(failure))
-
-        if failure.check(HttpError):
-            response = failure.value.response
-            self.logger.error(
-                'HttpError on %s (%s)',
-                response.url,
-                response.status,
-            )
-
-        elif failure.check(DNSLookupError):
-            request = failure.request
-            self.logger.error('DNSLookupError on %s', request.url)
-
-        elif failure.check(TimeoutError):
-            request = failure.request
-            self.logger.error('TimeoutError on %s', request.url)
-
     def start_requests(self):
-        """ This sets up the urls to scrape for each years.
-        """
-
+        """ This sets up the urls to scrape for each years."""
         urls = [
             'https://www.gov.uk/government/policies',
         ]
@@ -59,66 +34,44 @@ class GovSpider(scrapy.Spider):
         @returns requests 1
         """
 
-        for href in response.css('.artifact-title a::attr(href)').extract():
-            full_records_link = ''.join([href, '?show=full'])
-            yield Request(
-                url=response.urljoin(full_records_link),
-                callback=self.parse_article,
-                errback=self.on_error,
-            )
+        file_links = response.css(
+            '.attachment-details .title a::attr("href")'
+        ).extract()
+        other_document_links = response.css(
+            'li.document a::attr("href")'
+        ).extract()
 
-    def parse_article(self, response):
-        """ Scrape the article metadata from the detailed article page. Then,
-        redirect to the PDF page.
-
-        @url http://apps.who.int/iris/handle/10665/272346?show=full
-        @returns requests 1 1
-        @returns items 0 0
-        """
-
-        data_dict = {
-            'year': response.meta.get('year', {}),
-        }
-        data_dict['title'] = response.css(
-            'h2.page-header::text'
-        ).extract_first()
-
-        details_dict = defaultdict(list)
-        for line in response.css('.detailtable tr'):
-
-            # Each tr should have 2 to 3 td: attribute, value and language.
-            # We're only interested in the first and the second one.
-            tds = line.css('td::text').extract()
-            if len(tds) < 2:
-                continue
-
-            # Make attribute human readable
-            # (first part is always 'dc', so skip it)
-            attr_name = ' '.join(tds[0].split('.')[1:]).lower()
-            details_dict[attr_name].append(f'{tds[1]}')
-
-        # Scrap all the pdf on the page, passing scrapped metadata
-        href = response.css(
-            '.file-link a::attr("href")'
-        ).extract_first()
-
-        data_dict['subjects'] = details_dict.get('subject mesh', [])
-        data_dict['types'] = details_dict.get('type', [])
-        data_dict['authors'] = ', '.join(
-            details_dict.get('contributor author', [])
-        )
-        if href:
+        for href in other_document_links:
             yield Request(
                 url=response.urljoin(href),
-                callback=self.save_pdf,
+                callback=self.parse,
                 errback=self.on_error,
-                meta={'data_dict': data_dict}
             )
-        else:
-            err_link = href if href else ''.join([response.url, ' (referer)'])
-            self.logger.debug(
-                "Item is null - Canceling (%s)",
-                err_link
+
+        for href in file_links:
+            if response.headers.get(
+                'content-type', ''
+            ).split(b';')[0] != b'text/html':
+                return Request(
+                    url=response.urljoin(href),
+                    callback=self.save_pdf,
+                    errback=self.on_error
+                )
+            else:
+                yield Request(
+                    url=response.urljoin(href),
+                    callback=self.parse,
+                    errback=self.on_error,
+                )
+
+        next_page = response.css(
+            '.pub-c-pagination__item--next a::attr("href")'
+        ).extract_first()
+        if next_page:
+            yield Request(
+                url=response.urljoin(next_page),
+                callback=self.parse,
+                errback=self.on_error,
             )
 
     def save_pdf(self, response):
@@ -129,28 +82,24 @@ class GovSpider(scrapy.Spider):
         @returns requests 0 0
         """
 
-        content_type = response.headers.get('content-type', '').split(b';')[0]
-        is_pdf = b'application/pdf' == content_type
+        self.logger.info("1")
+
+        is_pdf = self._check_headers(response.headers)
 
         if not is_pdf:
             self.logger.info('Not a PDF, aborting (%s)', response.url)
             return
 
-        # Retrieve metadata
-        data_dict = response.meta.get('data_dict', {})
+        self.logger.info("2")
         # Download PDF file to /tmp
         filename = urlparse(response.url).path.split('/')[-1]
         with open('/tmp/' + filename, 'wb') as f:
             f.write(response.body)
-
+            self.logger.info('Writing file to the hard drive.')
         # Populate a WHOArticle Item
-        who_article = WHOArticle({
-                'title': data_dict.get('title', ''),
+        who_article = UNICEFArticle({
+                'title': '',
                 'uri': response.request.url,
-                'year': data_dict.get('year', ''),
-                'authors': data_dict.get('authors', ''),
-                'types': data_dict.get('types'),
-                'subjects': data_dict.get('subjects'),
                 'pdf': filename,
                 'sections': {},
                 'keywords': {}

--- a/wsf_scraping/spiders/nice_spider.py
+++ b/wsf_scraping/spiders/nice_spider.py
@@ -141,11 +141,11 @@ class NiceSpider(BaseSpider):
 
         if not href:
             # Second case: PDF is a single footer download link
-            href = response.css('.track-link::attr(href)').extract_first()
+            href = response.css('.track-link::attr("href")').extract_first()
 
         if not href:
             # Third case: Direct download link, without menu
-            href = response.css('#nice-download::attr(href)').extract_first()
+            href = response.css('#nice-download::attr("href")').extract_first()
 
         if href:
             return Request(

--- a/wsf_scraping/spiders/who_iris_spider.py
+++ b/wsf_scraping/spiders/who_iris_spider.py
@@ -9,8 +9,6 @@ from scrapy.utils.project import get_project_settings
 
 class WhoIrisSpider(BaseSpider):
     name = 'who_iris'
-    # All these parameters are optionnal,
-    # but it is good to set a result per page ubove 250, to limit query number
     data = {}
 
     custom_settings = {


### PR DESCRIPTION
This PR adds the gov.uk website to the scraping list ✨ 

It also remove the legacy part of the PDF parser module, some useless comments on the who spider and add some quotes around the href attribute of the nice spider responses.

It may look a bit long, but you can safely ignore the changes in the pdf_parser module, and the structure of the gov_spider is the same as the other three spiders 👍 