### PR TITLE
Fix error message due to who item lacking an attribute

### DIFF
--- a/wsf_scraping/items.py
+++ b/wsf_scraping/items.py
@@ -16,6 +16,7 @@ class WHOArticle(BaseArticle):
     year = scrapy.Field()
     types = scrapy.Field()
     subjects = scrapy.Field()
+    authors = scrapy.Field()
 
 
 class NICEArticle(BaseArticle):


### PR DESCRIPTION
Who spider lacked the `authors` attribute for its item. This PR add it.