### PR TITLE
Refactor the file management part of the spiders

### DIFF
--- a/pdf_parser/pdf_parse.py
+++ b/pdf_parser/pdf_parse.py
@@ -19,6 +19,7 @@ def parse_pdf_document(document):
     cmd = [
             'pdftohtml',
             '-i',
+            '-q',
             '-xml',
             document.name,
             parsed_path
@@ -28,11 +29,10 @@ def parse_pdf_document(document):
         with open(os.devnull, 'w') as FNULL:
             subprocess.check_call(cmd, stdout=FNULL)
     except subprocess.CalledProcessError as e:
-        err = e.sdterr if e.stderr else ''
         logger.warning(
-            "The pdf [%s] could not be converted: %s",
+            "The pdf [%s] could not be converted: %r",
             document.name,
-            err,
+            e.stderr,
         )
         return None
 

--- a/pdf_parser/pdf_parse.py
+++ b/pdf_parser/pdf_parse.py
@@ -16,6 +16,7 @@ def parse_pdf_document(document):
 
     logger = logging.getLogger(__name__)
     parsed_path = document.name.replace('.pdf', '.xml')
+    # Run pdftohtml on the document, and output an xml formated document
     cmd = [
             'pdftohtml',
             '-i',

--- a/tests/test_pdf_objects.py
+++ b/tests/test_pdf_objects.py
@@ -1,6 +1,6 @@
 import unittest
 import json
-from pdf_parser.pdf_parse import parse_pdf_document, parse_pdf_document_pdftxt
+from pdf_parser.pdf_parse import parse_pdf_document
 from pdf_parser.objects.PdfObjects import PdfFile
 
 TEST_PDF = 'tests/pdfs/test_pdf.pdf'
@@ -59,28 +59,21 @@ class TestPdfObjects(unittest.TestCase):
     def setUp(self):
         self.test_file = open(TEST_PDF, 'rb')
         self.pdf_file_object = parse_pdf_document(self.test_file)
-        self.pdf_file_object_2 = parse_pdf_document_pdftxt(self.test_file)
 
     def tearDown(self):
         self.test_file.close()
 
-    def test_pdftotext_equal(self):
-        self.assertEqual(
-            len(self.pdf_file_object.pages),
-            len(self.pdf_file_object_2.pages)
-        )
-
     def test_mean(self):
         font_mean = self.pdf_file_object.get_mean_font_size()
-        self.assertEqual(font_mean, 13)
+        self.assertEqual(font_mean, 24)
 
     def test_upper_mean(self):
         upper_mean = self.pdf_file_object.get_upper_mean_font_size()
-        self.assertEqual(upper_mean, 15)
+        self.assertEqual(upper_mean, 29)
 
     def test_list_by_size(self):
         list_fonts = self.pdf_file_object.get_font_size_list()
-        self.assertEqual(list_fonts, [11, 13, 15])
+        self.assertEqual(list_fonts, [29, 22])
 
     def test_bold(self):
         list_bold_lines = self.pdf_file_object.get_bold_lines()

--- a/wsf_scraping/pipelines.py
+++ b/wsf_scraping/pipelines.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import os
-import tempfile
 import logging
 from scrapy import spiderloader
 from tools import DatabaseConnector, DynamoDBConnector
@@ -33,12 +32,7 @@ class WsfScrapingPipeline(object):
         spiders = spider_loader.list()
 
         for spider_name in spiders:
-            folder_path = os.path.join(
-                os.path.curdir,
-                'results',
-                'pdfs',
-                spider_name
-            )
+            folder_path = os.path.join('results', 'pdfs', spider_name)
             os.makedirs(folder_path, exist_ok=True)
 
         if self.settings['DATABASE_ADAPTOR'] == 'dynamodb':
@@ -60,18 +54,18 @@ class WsfScrapingPipeline(object):
         download_only = self.settings['DOWNLOAD_ONLY']
         feed = self.settings['FEED_CONFIG']
         pdf_result_path = os.path.join(
-            os.path.curdir,
             'results',
             'pdfs',
             spider_name,
+            os.path.basename(item['pdf']),
         )
 
         # Convert PDF content to text format
-        with open(base_pdf_path, 'rb') as f:
+        with open(item['pdf'], 'rb') as f:
             if download_only:
                 os.rename(
-                    os.path.join(tempfile.gettempdir(), item['pdf']),
-                    os.path.join(pdf_result_path, item['pdf'])
+                    item['pdf'],
+                    pdf_result_path,
                 )
                 return item
 
@@ -113,12 +107,12 @@ class WsfScrapingPipeline(object):
                 pass
             else:
                 os.rename(
-                    os.path.join(tempfile.gettempdir(), item['pdf']),
-                    os.path.join(pdf_result_path, item['pdf'])
+                    item['pdf'],
+                    pdf_result_path,
                 )
         else:
             try:
-                os.remove(base_pdf_path)
+                os.remove(item['pdf'])
             except FileNotFoundError:
                 self.logger.warning(
                     "The file couldn't be found, and wasn't deleted."
@@ -128,18 +122,20 @@ class WsfScrapingPipeline(object):
     def process_item(self, item, spider):
         """Process items sent by the spider."""
 
-        base_pdf_path = os.path.join(tempfile.gettempdir(), item['pdf'])
-        file_hash = get_file_hash(base_pdf_path)
+        if not item['pdf']:
+            raise DropItem(
+                'Empty filename, could not parse the pdf.'
+            )
+        file_hash = get_file_hash(item['pdf'])
         if self.database.is_scraped(file_hash):
             # File is already scraped in the database
             raise DropItem(
                 'Item footprint is already in the database'
             )
-        if not item['pdf']:
-            raise DropItem(
-                'Empty filename, could not parse the pdf.'
-            )
-        full_item = self.check_keywords(item, spider.name, base_pdf_path)
+        full_item = self.check_keywords(item, spider.name, item['pdf'])
+
+        # Remove the path from the value we are storing
+        full_item['pdf'] = os.path.basename(item['pdf'])
         full_item['hash'] = file_hash
         full_item['provider'] = spider.name
         self.database.insert_article(file_hash, item['uri'])

--- a/wsf_scraping/spiders/base_spider.py
+++ b/wsf_scraping/spiders/base_spider.py
@@ -34,14 +34,15 @@ class BaseSpider(scrapy.Spider):
         return desired_extension == content_type
 
     def _save_file(self, url, response_body):
-        filename = os.path.basename(urlparse(url).path).lower()
+        filename = os.path.basename(urlparse(url).path)
+        tempdir = tempfile.mkdtemp()
         if filename:
-            if not filename.endswith('.pdf'):
+            if not filename.lower().endswith('.pdf'):
                 filename = filename + '.pdf'
-            filepath = os.path.join(tempfile.gettempdir(), filename)
+            filepath = os.path.join(tempdir, filename)
             with open(filepath, 'wb') as f:
                 f.write(response_body)
-            return filename
+            return filepath
         else:
             self.logger.warning('Empty filename, could not save the file.')
             return ''

--- a/wsf_scraping/spiders/base_spider.py
+++ b/wsf_scraping/spiders/base_spider.py
@@ -44,5 +44,8 @@ class BaseSpider(scrapy.Spider):
                 f.write(response_body)
             return filepath
         else:
-            self.logger.warning('Empty filename, could not save the file.')
+            self.logger.warning(
+                 'Empty filename, could not save the file. [Url: %s]',
+                 url
+            )
             return ''

--- a/wsf_scraping/spiders/base_spider.py
+++ b/wsf_scraping/spiders/base_spider.py
@@ -1,7 +1,10 @@
 import scrapy
+import os
+import tempfile
 from scrapy.spidermiddlewares.httperror import HttpError
 from twisted.internet.error import DNSLookupError
 from twisted.internet.error import TimeoutError
+from urllib.parse import urlparse
 
 
 class BaseSpider(scrapy.Spider):
@@ -29,3 +32,16 @@ class BaseSpider(scrapy.Spider):
                        desired_extension=b'application/pdf'):
         content_type = response_headers.get('content-type', '').split(b';')[0]
         return desired_extension == content_type
+
+    def _save_file(self, url, response_body):
+        filename = os.path.basename(urlparse(url).path).lower()
+        if filename:
+            if not filename.endswith('.pdf'):
+                filename = filename + '.pdf'
+            filepath = os.path.join(tempfile.gettempdir(), filename)
+            with open(filepath, 'wb') as f:
+                f.write(response_body)
+            return filename
+        else:
+            self.logger.warning('Empty filename, could not save the file.')
+            return ''

--- a/wsf_scraping/spiders/msf_spider.py
+++ b/wsf_scraping/spiders/msf_spider.py
@@ -53,11 +53,8 @@ class MSFSpider(BaseSpider):
             self.logger.info('Not a PDF, aborting (%s)', response.url)
             return
 
-        filename = ''.join([response.url.split('/')[-1], '.pdf'])
-
-        with open('/tmp/' + filename, 'wb') as f:
-            f.write(response.body)
-
+        # Download PDF file to /tmp
+        filename = self._save_file(response.url, response.body)
         msf_article = MSFArticle({
                 'title': '',
                 'uri': response.request.url,

--- a/wsf_scraping/spiders/nice_spider.py
+++ b/wsf_scraping/spiders/nice_spider.py
@@ -177,11 +177,8 @@ class NiceSpider(BaseSpider):
             self.logger.info('Not a PDF, aborting (%s)', response.url)
             return
 
-        filename = ''.join([response.url.split('/')[-1], '.pdf'])
-
-        with open('/tmp/' + filename, 'wb') as f:
-            f.write(response.body)
-
+        # Download PDF file to /tmp
+        filename = self._save_file(response.url, response.body)
         nice_article = NICEArticle({
                 'title': data_dict.get('title', ''),
                 'uri': response.request.url,

--- a/wsf_scraping/spiders/unicef_spider.py
+++ b/wsf_scraping/spiders/unicef_spider.py
@@ -1,5 +1,4 @@
 import scrapy
-from urllib.parse import urlparse
 from scrapy.http import Request
 from wsf_scraping.items import UNICEFArticle
 from .base_spider import BaseSpider
@@ -35,7 +34,7 @@ class UnicefSpider(BaseSpider):
 
         @url https://data.unicef.org/resources/resource-type/publication/
         @returns items 0 0
-        @returns requests 115
+        @returns requests 1
         """
 
         for href in response.css('h2 a::attr(href)').extract():
@@ -80,11 +79,7 @@ class UnicefSpider(BaseSpider):
             return
 
         # Download PDF file to /tmp
-        filename = urlparse(response.url).path.split('/')[-1]
-        with open('/tmp/' + filename, 'wb') as f:
-            f.write(response.body)
-
-        # Populate a UNICEFArticle Item
+        filename = self._save_file(response.url, response.body)
         unicef_article = UNICEFArticle({
                 'title': response.meta.get('title', ''),
                 'uri': response.request.url,

--- a/wsf_scraping/spiders/who_iris_spider.py
+++ b/wsf_scraping/spiders/who_iris_spider.py
@@ -1,5 +1,5 @@
 import scrapy
-from urllib.parse import urlparse, urlencode
+from urllib.parse import urlencode
 from scrapy.http import Request
 from collections import defaultdict
 from wsf_scraping.items import WHOArticle
@@ -163,12 +163,9 @@ class WhoIrisSpider(BaseSpider):
 
         # Retrieve metadata
         data_dict = response.meta.get('data_dict', {})
-        # Download PDF file to /tmp
-        filename = urlparse(response.url).path.split('/')[-1]
-        with open('/tmp/' + filename, 'wb') as f:
-            f.write(response.body)
 
-        # Populate a WHOArticle Item
+        # Download PDF file to /tmp
+        filename = self._save_file(response.url, response.body)
         who_article = WHOArticle({
                 'title': data_dict.get('title', ''),
                 'uri': response.request.url,


### PR DESCRIPTION
♻️ Following our discussion on the last two spiders, this PR moves the file management part of the spider in the base class.

👌 It also changes to the `os` module to manage urls and paths from string manipulation and the `tempfile` module to manage temporary files.

❗️Note that as we want to keep some pdfs and their names, we're not using the `Tempfile` object to store files.