### PR TITLE
Rds compatibility

### DIFF
--- a/pdf_parser/pdf_parse.py
+++ b/pdf_parser/pdf_parse.py
@@ -39,6 +39,7 @@ def parse_pdf_document(document):
 
     html_file = open(parsed_path, 'rb')
     soup = bs(html_file.read(), 'html.parser')
+    text = soup.text
     file_pages = []
     pages = soup.find_all('page')
 
@@ -75,7 +76,7 @@ def parse_pdf_document(document):
     pdf_file = PdfFile(file_pages)
     html_file.close()
     os.remove(parsed_path)
-    return pdf_file
+    return pdf_file, text
 
 
 def grab_section(pdf_file, keyword):

--- a/scraper.sql
+++ b/scraper.sql
@@ -49,7 +49,7 @@ CREATE TABLE IF NOT EXISTS publication
     pub_year  VARCHAR(4),
     pdf_text TEXT,
     scrape_again BOOLEAN,
-    fk_provider_id INT REFERENCES "provider",
+    id_provider INT REFERENCES "provider",
     datetime_creation TIMESTAMP,
     datetime_update TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/scraper.sql
+++ b/scraper.sql
@@ -1,0 +1,85 @@
+CREATE TABLE IF NOT EXISTS section
+(
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255),
+    datetime_creation TIMESTAMP,
+    datetime_update TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS keyword
+(
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255),
+    datetime_creation TIMESTAMP,
+    datetime_update TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS provider
+(
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255),
+    datetime_creation TIMESTAMP,
+    datetime_update TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS type
+(
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255),
+    datetime_creation TIMESTAMP,
+    datetime_update TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS subject
+(
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255),
+    datetime_creation TIMESTAMP,
+    datetime_update TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS publication
+(
+    id SERIAL PRIMARY KEY,
+    title VARCHAR(1024),
+    url TEXT,
+    pdf_name VARCHAR(1024),
+    file_hash VARCHAR(32),
+    authors VARCHAR(1024),
+    pub_year  VARCHAR(4),
+    pdf_text TEXT,
+    scrape_again BOOLEAN,
+    fk_provider_id INT REFERENCES "provider",
+    datetime_creation TIMESTAMP,
+    datetime_update TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS publications_sections
+(
+    id_publication INT REFERENCES "publication",
+    id_section INT REFERENCES "section",
+    text_content TEXT,
+    PRIMARY KEY(id_publication, id_section)
+);
+
+CREATE TABLE IF NOT EXISTS publications_keywords
+(
+    id_publication INT REFERENCES "publication",
+    id_keyword INT REFERENCES "keyword",
+    text_content TEXT,
+    PRIMARY KEY(id_publication, id_keyword)
+);
+
+CREATE TABLE IF NOT EXISTS publications_types
+(
+    id_publication INT REFERENCES "publication",
+    id_type INT REFERENCES "type",
+    PRIMARY KEY(id_publication, id_type)
+);
+
+CREATE TABLE IF NOT EXISTS publications_subjects
+(
+    id_publication INT REFERENCES "publication",
+    id_subject INT REFERENCES "subject",
+    PRIMARY KEY(id_publication, id_subject)
+);

--- a/tests/test_pdf_objects.py
+++ b/tests/test_pdf_objects.py
@@ -58,7 +58,7 @@ class TestPdfObjects(unittest.TestCase):
 
     def setUp(self):
         self.test_file = open(TEST_PDF, 'rb')
-        self.pdf_file_object = parse_pdf_document(self.test_file)
+        self.pdf_file_object, self.text = parse_pdf_document(self.test_file)
 
     def tearDown(self):
         self.test_file.close()

--- a/tests/test_pdf_parser_tools.py
+++ b/tests/test_pdf_parser_tools.py
@@ -9,7 +9,7 @@ class TestTools(unittest.TestCase):
 
     def setUp(self):
         self.test_file = open(TEST_PDF, 'rb')
-        self.pdf_file_object = parse_pdf_document(self.test_file)
+        self.pdf_file_object, self.text = parse_pdf_document(self.test_file)
 
     def tearDown(self):
         self.test_file.close()

--- a/tools/dbTools.py
+++ b/tools/dbTools.py
@@ -125,11 +125,14 @@ class DatabaseConnector:
         """
         if limit > 0:
             self._execute(
-                "SELECT title, file_hash, url FROM article LIMIT %s OFFSET %s",
+                """
+                    SELECT title, file_hash, url
+                    FROM publication LIMIT %s OFFSET %s
+                """,
                 (offset, limit,)
             )
         else:
-            self._execute("SELECT title, file_hash, url FROM article")
+            self._execute("SELECT title, file_hash, url FROM publication")
         result = []
         for article in self.cursor.fetchall():
             result.append(article)

--- a/tools/dbTools.py
+++ b/tools/dbTools.py
@@ -2,6 +2,7 @@ import psycopg2
 import psycopg2.extras
 import logging
 import os
+from datetime import datetime
 
 
 class DatabaseConnector:
@@ -101,19 +102,22 @@ class DatabaseConnector:
 
     def is_scraped(self, file_hash):
         """Check if an article had already been scraped by looking for its file
-        hash into the database. Is the `scrap_again` attribute is true, return
-        False anyway.
+        hash into the database. If the article exists, returns its id and its
+        `scrape_again` value
         """
         self._execute(
             """
-            SELECT id
-            FROM article
-            WHERE file_hash = %s AND scrap_again IS NOT TRUE;
+            SELECT id, scrape_again
+            FROM publication
+            WHERE file_hash = %s;
             """,
             (file_hash,)
         )
         result = self.cursor.fetchone()
-        return result or None
+        if result:
+            return result.id, result.scrape_again
+        else:
+            return (None, None)
 
     def get_articles(self, offset=0, limit=-1):
         """Return a list of articles. By default, returns every articles. This
@@ -130,6 +134,91 @@ class DatabaseConnector:
         for article in self.cursor.fetchall():
             result.append(article)
         return result
+
+    def insert_full_article(self, article, id_provider):
+        """Insert an entire article in the database and return its id."""
+        self._execute(
+            """
+            INSERT INTO publication(title, url, pdf_name, file_hash,
+                             authors, pub_year, pdf_text,
+                             id_provider, datetime_creation)
+            VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s)
+            RETURNING id;
+            """,
+            (article['title'], article['uri'], article['pdf'],
+             article['hash'], article.get('authors', ''), article['year'],
+             article['text'], id_provider, datetime.now(),)
+        )
+        return self.cursor.fetchone().id
+
+    def update_full_article(self, article):
+        self._execute(
+            """
+            UPDATE publication
+            SET
+                title=%s,
+                url=%s,
+                pdf_name=%s,
+                file_hash=%s,
+                authors=%s,
+                pub_year=%s,
+                pdf_text=%s,
+            WHERE id=%s;
+            """,
+            (article['title'], article['uri'], article['pdf'],
+             article['hash'], article.get('authors', ''), article['year'],
+             article['text'], article['id'],)
+        )
+
+    def insert_joints_and_text(self, table, data, id_article):
+        """Create both a name table and a joint table between a publication and
+        another item with a 0-n or 1-n cardinality.
+        """
+        res = []
+        names = {}
+        items = data.get(f'{table}s', {})
+        for name, text_value in items.items():
+            db_name_id = self.get_or_create_name(name, table)
+
+            self._execute(
+                """
+                    INSERT
+                    INTO publications_{table}s(
+                        id_publication,
+                        id_{table},
+                        text_content
+                    )
+                    VALUES(%s, %s, %s);
+                """.format(table=table),
+                (id_article, db_name_id, text_value,)
+            )
+        res_names = []
+        for id, name in enumerate(names):
+            res_names.append({
+                'id': id,
+                'name': name,
+                'datetime_creation': datetime.now(),
+            })
+        return res, res_names
+
+    def get_or_create_name(self, name, table):
+        self._execute(
+            'SELECT id FROM {table} WHERE name = %s'.format(table=table),
+            (name,)
+        )
+        item = self.cursor.fetchone()
+        if item:
+            return item.id
+        else:
+            self._execute(
+                """
+                INSERT INTO {table}(name)
+                VALUES(%s)
+                RETURNING id;
+                """.format(table=table),
+                (name,)
+            )
+            return self.cursor.fetchone().id
 
     def insert_article(self, file_hash, url):
         """Try to insert an article, composed by its file hash and url,

--- a/wsf_scraping/items.py
+++ b/wsf_scraping/items.py
@@ -9,6 +9,7 @@ class BaseArticle(scrapy.Item):
     sections = scrapy.Field()
     keywords = scrapy.Field()
     hash = scrapy.Field()
+    text = scrapy.Field()
     provider = scrapy.Field()
     date_scraped = scrapy.Field()
 

--- a/wsf_scraping/pipelines.py
+++ b/wsf_scraping/pipelines.py
@@ -153,10 +153,27 @@ class WsfScrapingPipeline(object):
                 full_item,
                 id_provider
             )
-            self.database.insert_joints_and_text('section', full_item,
-                                                 id_publication)
-            self.database.insert_joints_and_text('keyword', full_item,
-                                                 id_publication)
+            self.database.insert_joints_and_text(
+                'section',
+                full_item.get('sections'),
+                id_publication
+            )
+            self.database.insert_joints_and_text(
+                'keyword',
+                full_item.get('keywords'),
+                id_publication
+            )
+            self.database.insert_joints(
+                'type',
+                full_item.get('types'),
+                id_publication
+            )
+            self.database.insert_joints(
+                'subjects',
+                full_item.get('types'),
+                id_publication
+            )
+
         self.database.insert_article(file_hash, item['uri'])
 
         return full_item

--- a/wsf_scraping/pipelines.py
+++ b/wsf_scraping/pipelines.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-
 import os
 import logging
 from datetime import datetime
@@ -75,10 +74,12 @@ class WsfScrapingPipeline(object):
                 item['pdf']
             )
 
-            pdf_file = parse_pdf_document(f)
+            pdf_file, pdf_text = parse_pdf_document(f)
 
             if not pdf_file:
                 return item
+
+            item['text'] = pdf_text
 
             for keyword in self.section_keywords:
                 # Fetch references or other keyworded list
@@ -128,7 +129,8 @@ class WsfScrapingPipeline(object):
                 'Empty filename, could not parse the pdf.'
             )
         file_hash = get_file_hash(item['pdf'])
-        if self.database.is_scraped(file_hash):
+        id_publication, scrape_again = self.database.is_scraped(file_hash)
+        if id_publication and not scrape_again:
             # File is already scraped in the database
             raise DropItem(
                 'Item footprint is already in the database'
@@ -140,6 +142,21 @@ class WsfScrapingPipeline(object):
         full_item['hash'] = file_hash
         full_item['provider'] = spider.name
         full_item['date_scraped'] = datetime.now().strftime('%Y%m%d')
+        if scrape_again:
+            full_item['id'] = id_publication
+            self.database.update_full_article(full_item)
+        else:
+            id_provider = self.database.get_or_create_name(
+                spider.name, 'provider'
+            )
+            id_publication = self.database.insert_full_article(
+                full_item,
+                id_provider
+            )
+            self.database.insert_joints_and_text('section', full_item,
+                                                 id_publication)
+            self.database.insert_joints_and_text('keyword', full_item,
+                                                 id_publication)
         self.database.insert_article(file_hash, item['uri'])
 
         return full_item


### PR DESCRIPTION
This PR aims to bring integral article saves to an RDS instance of a Postgresql database. It mostly modify the `dbTools.py` file, adding it a few methods to add both articles and joint tables.
These changes are called mostly in `pipelines.py`, as it is where the article is saved.

Also changes a bit of the pdf_parser module, to have it returning a text version of the pdf as well as its parsed and analysed version.

This is a temporary update, soon to be updated to a SQLAlchemy version to bring more flexibility to the database connector.