### PR TITLE
Add Contributing guidelines and PR template to the repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,95 @@
+# Contributing
+
+:tada: First of all, welcome to this repository, and thanks for your interest, whether you want to contribute
+or simply are interested in opening an issue.
+
+When contributing to this repository, please first discuss the change you wish to make by creating an issue before making a change.
+
+Please note we have a code of conduct, please follow it in all your interactions with the project.
+
+## Pull Request Process
+
+1. Before pushing your code, please make sure to have it covered by some unit tests. Also make sure that the code passes both your tests and the other tests.
+
+2. Use our pull request template to submit any changes to the code, even minor.
+
+3. This project is developed using Python3.6 (currently the last Python version),
+   and follow the PEP8 (https://www.python.org/dev/peps/pep-0008/) rules. You should enforce this
+   behaviour and also use Pyflakes to check your code for unused libraries.
+
+## Code of Conduct
+
+### Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+We expect you to use this code with respect for people involved in the analysis
+of the references you want to parse.
+
+### Our Standards
+
+Examples of behaviours which contribute to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+### Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+### Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team.
+All complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,31 @@
+# Description
+
+Please include a summary of the changes this PR introduces for the codebase.
+Also specify if some sections need special attention, and why you want to introduce this change.
+
+Make sure to split changes across multiple pull requests, as we won't review bundled pull requests.
+
+Finally, make sure your PR follows our code of conduct before posting (Check our [contributing guidelines](CONTRIBUTING.md) if you're not sure).
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] :bug: Bug fix (Add `Fix #(issue)` to your PR)
+- [ ] :sparkles: New feature
+- [ ] :fire: Breaking change
+- [ ] :memo: Documentation update
+
+# How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes. Provide instructions so we can run the tests. Please also list any relevant details for your test configuration:
+
+# Checklist:
+
+- [ ] My code follows the style guidelines of this project (pep8 AND pyflakes)
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] If needed, I changed related parts of the documentation
+- [ ] I included tests in my PR
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules
+- [ ] If my PR aims to fix an issue, I referenced it using `#(issue)`


### PR DESCRIPTION
⬆️ Says it all. 

We need these file to open source the repository in a short future. They are the same as for the reference parser 👍 