### PR TITLE
[WiP] Fix the WHO scraping task

### DIFF
--- a/wsf_scraping/items.py
+++ b/wsf_scraping/items.py
@@ -5,9 +5,9 @@ import scrapy
 class BaseArticle(scrapy.Item):
     def __repr__(self):
         return repr({
-            'title': self['title'],
-            'uri': self['uri'],
-            'provider': self['provider'],
+            'title': self.get('title'),
+            'uri': self.get('uri'),
+            'provider': self.get('provider'),
         })
 
     title = scrapy.Field()

--- a/wsf_scraping/items.py
+++ b/wsf_scraping/items.py
@@ -3,6 +3,13 @@ import scrapy
 
 
 class BaseArticle(scrapy.Item):
+    def __repr__(self):
+        return repr({
+            'title': self['title'],
+            'uri': self['uri'],
+            'provider': self['provider'],
+        })
+
     title = scrapy.Field()
     year = scrapy.Field()
     uri = scrapy.Field()

--- a/wsf_scraping/pipelines.py
+++ b/wsf_scraping/pipelines.py
@@ -81,7 +81,9 @@ class WsfScrapingPipeline(object):
             if not pdf_file:
                 return item
 
-            item['text'] = pdf_text
+            # In some case, the text contains NUL bit that are not allowed in
+            # PSQL. We just remove them.
+            item['text'] = pdf_text.replace('\0', '')
 
             for keyword in self.section_keywords:
                 # Fetch references or other keyworded list

--- a/wsf_scraping/pipelines.py
+++ b/wsf_scraping/pipelines.py
@@ -163,8 +163,8 @@ class WsfScrapingPipeline(object):
                 id_publication
             )
             self.database.insert_joints(
-                'subjects',
-                full_item.get('types'),
+                'subject',
+                full_item.get('subjects'),
                 id_publication
             )
 

--- a/wsf_scraping/spiders/who_iris_spider.py
+++ b/wsf_scraping/spiders/who_iris_spider.py
@@ -128,8 +128,8 @@ class WhoIrisSpider(BaseSpider):
             '.file-link a::attr("href")'
         ).extract_first()
 
-        data_dict['subjects'] = details_dict.get('subject mesh', [])
-        data_dict['types'] = details_dict.get('type', [])
+        data_dict['subjects'] = set(details_dict.get('subject mesh', []))
+        data_dict['types'] = set(details_dict.get('type', []))
         data_dict['authors'] = ', '.join(
             details_dict.get('contributor author', [])
         )


### PR DESCRIPTION
# Description

The WHO scraping was just re-enabled and failed for a few reasons. This PR aims to fix the following issues:
 - Presence of a NUL char in some PDF texts made the PSQL transaction fail
 - Typo in the table name (`subjects` instead of `subject`)
 - Integrity constraint violations: the same subject could appear multiple times in the PDF metadata. Replace it by a set to respect the integrity constraint

It also changes the `__repr__` of items, to only show the title, url and organisation. Displaying the full item led to a lot of noise in the logs since we now store the full PDF text.

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)
- [ ] :sparkles: New feature
- [ ] :fire: Breaking change
- [ ] :memo: Documentation update

# How Has This Been Tested?

Local scraping of WHO documents and new scraping on AWS.

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If needed, I changed related parts of the documentation
- [x] I included tests in my PR (Bugfix, no tests needed)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
