### PR TITLE
Add parliament scraping to the scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ where `SPIDER_TO_RUN` is one of:
   * `nice`
   * `unicef`
   * `msf`
+  * `parliament`
 
 If you need to run outside docker, Dockerfile.base and entrypoint.sh
 should point you in the right direction.
@@ -84,3 +85,10 @@ Some providers will have additional parameters:
 |Attribute|Description|
 |---------|-----------|
 |year     | the publication year of the document|
+
+### Parliament
+
+|Attribute|Description|
+|---------|-----------|
+|year     | the publication year of the document|
+|types    | the type of the document |

--- a/tools/dbTools.py
+++ b/tools/dbTools.py
@@ -34,7 +34,9 @@ class DatabaseConnector:
         except AttributeError:
             if hasattr(self, 'logger'):
                 # __del__ can be called before self.logger is created.
-                self.logger.warning('Tried to close a non-existent connection.')
+                self.logger.warning(
+                    'Tried to close a non-existent connection.'
+                )
 
     def _execute(self, query, params=()):
         """Try to execute the SQL query passed by the query parameter, with the
@@ -66,9 +68,9 @@ class DatabaseConnector:
         )
 
     def get_scraping_info(self, file_hash):
-        """Check if an publication had already been scraped by looking for its file
-        hash into the database. If the publication exists, returns its id and
-        its `scrape_again` value
+        """Check if an publication had already been scraped by looking for its
+        file hash into the database. If the publication exists, returns its id
+        and its `scrape_again` value
         """
         self._execute(
             """
@@ -82,8 +84,9 @@ class DatabaseConnector:
         return result
 
     def get_publications(self, offset=0, limit=-1):
-        """Return a list of publications. By default, returns every publications. This
-        method accepts start and end arguments to paginate results.
+        """Return a list of publications. By default, returns every
+        publications. This method accepts start and end arguments to
+        paginate results.
         """
         if limit > 0:
             self._execute(

--- a/wsf_scraping/items.py
+++ b/wsf_scraping/items.py
@@ -42,3 +42,7 @@ class MSFArticle(BaseArticle):
 
 class GovArticle(BaseArticle):
     pass
+
+
+class ParliamentArticle(BaseArticle):
+    types = scrapy.Field()

--- a/wsf_scraping/pipelines.py
+++ b/wsf_scraping/pipelines.py
@@ -166,7 +166,6 @@ class WsfScrapingPipeline(object):
                 id_publication
             )
 
-            self.database.insert_publication(item['hash'], item['uri'])
         elif db_item.scrape_again:
             full_item = self.check_keywords(item, spider.name, item['pdf'])
             full_item['id'] = db_item.id

--- a/wsf_scraping/spiders/parliament_spider.py
+++ b/wsf_scraping/spiders/parliament_spider.py
@@ -1,0 +1,134 @@
+import scrapy
+from scrapy.http import Request
+from wsf_scraping.items import ParliamentArticle
+from .base_spider import BaseSpider
+
+
+class ParliamentSpider(BaseSpider):
+    name = 'parliament'
+
+    custom_settings = {
+        'JOBDIR': 'crawls/parliament',
+        'ROBOTSTXT_OBEY': False
+    }
+
+    def start_requests(self):
+        """This sets up the initial urls."""
+
+        query_list = [
+            'Parameters.Fields.all=',
+            'Parameters.Fields.all-target=',
+            'Parameters.Fields.phrase=',
+            'Parameters.Fields.phrase-target=',
+            'Parameters.Fields.any=',
+            'Parameters.Fields.any-target=',
+            'Parameters.Fields.exclude=',
+            'Parameters.Fields.exclude-target=',
+            'Parameters.Fields.house=House+of+Commons',
+            'Parameters.Fields.house=House+of+Lords',
+            'Parameters.Fields.member=',
+            'Parameters.Fields.subject=',
+            'Parameters.Fields.reference=',
+            'When%3A=date',
+            'Parameters.Fields.date=01%2F01%2F1980',
+            'Parameters.Fields.date=04%2F10%2F2018',
+            'Parameters.PageSize=100'
+        ]
+        base_url = 'http://search-material.parliament.uk/search'
+        query_params = '&'.join(query_list)
+        url = base_url + '?' + query_params
+
+        self.logger.info('Initial url: %s', url)
+        yield scrapy.Request(
+            url=url,
+            callback=self.parse,
+            errback=self.on_error,
+            dont_filter=True,
+        )
+
+    def parse(self, response):
+        """Parse the articles listing page and go to the next one."""
+
+        for li in response.css('#results li'):
+            # direct pdfs links ends with pdf
+            link = li.css('h4 a::attr(href)').extract_first().strip()
+            meta = li.css('.resultdetails::text').extract()
+            meta = [m.strip() for m in meta]
+
+            # The date is always in format `dd Mmm YYYY`
+            title = li.css('h4 a::text').extract_first().strip()
+            year = meta[0][-4:]
+            type = meta[1]
+            if link.endswith('pdf'):
+                yield Request(
+                    url=response.urljoin(link),
+                    meta={
+                        'title': title,
+                        'year': year,
+                        'type': type
+                    },
+                    callback=self.save_pdf,
+                    errback=self.on_error,
+                )
+            else:
+                yield Request(
+                    url=response.urljoin(link),
+                    meta={
+                        'title': title,
+                        'year': year,
+                        'type': type
+                    },
+                    callback=self.parse_others,
+                    errback=self.on_error,
+                )
+
+        next = response.css('.next a::attr(href)').extract_first()
+        if next:
+            yield Request(
+                url=response.urljoin(next),
+                callback=self.parse,
+                errback=self.on_error,
+            )
+
+    def parse_others(self, response):
+        """Try to retrieve a pdf from a depth 2 page. If no pdf is found
+        at this point, we stop looking this way.
+        """
+
+        for href in response.css('a::attr(href)').extract():
+            if href.endswith('pdf'):
+                yield Request(
+                    url=response.urljoin(href),
+                    meta={
+                        'title': response.meta.get('title'),
+                        'year': response.meta.get('year'),
+                        'type': response.meta.get('type'),
+                    },
+                    callback=self.save_pdf,
+                    errback=self.on_error,
+                )
+
+    def save_pdf(self, response):
+        """Retrieve the pdf file and scan it to scrape keywords and sections.
+        """
+
+        is_pdf = self._check_headers(response.headers)
+
+        if not is_pdf:
+            self.logger.info('Not a PDF, aborting (%s)', response.url)
+            return
+
+        # Download PDF file to /tmp
+        filename = self._save_file(response.url, response.body)
+        parliament_article = ParliamentArticle({
+                'title': response.meta.get('title'),
+                'year': response.meta.get('year'),
+                'types': [response.meta.get('type')],
+                'uri': response.request.url,
+                'pdf': filename,
+                'sections': {},
+                'keywords': {}
+            }
+        )
+
+        yield parliament_article


### PR DESCRIPTION
# Description

This PR aims to let us scrape the parliament website to find Wellcome references into debates, commitees and other documents. To achieve this goal, this PR:
- Adds a `parliament_spider` (`scrapy crawl parliament`)
- Fix a couple of bugs spotted dureing the developement
- Update the related documentation

Fix #98 

## Type of change

Please delete options that are not relevant.

- [x] :sparkles: New feature
- [x] :memo: Documentation update

# How Has This Been Tested?

Local runs only. We should stop including spider contracts and find a better way to test spiders.

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If needed, I changed related parts of the documentation
- [ ] I included tests in my PR [Not relevant]
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
