### PR TITLE
Add a push option to the makefile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ Dockerfile
 .gitignore
 var/*
 results/*
+data/*

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .DEFAULT_GOAL := all
 
 IMAGE := uk.ac.wellcome/web-scraper
+ECR_IMAGE := 160358319781.dkr.ecr.eu-west-1.amazonaws.com/$(IMAGE)
 VERSION := 2018.10.0
 
 .PHONY: base_image
@@ -8,8 +9,21 @@ base_image:
 	docker build -t web-scraper.base -f Dockerfile.base .
 
 .PHONY: image
-image:
-	docker build -t $(IMAGE):$(VERSION) -t $(IMAGE):latest .
+image: base_image
+	docker build \
+		-t $(IMAGE):$(VERSION) \
+		-t $(IMAGE):latest \
+		-t $(ECR_IMAGE):$(VERSION) \
+		-t $(ECR_IMAGE):latest \
+		.
+
+.PHONY: push
+push: image
+	$$(aws ecr get-login --no-include-email --region eu-west-1) && \
+	docker push $(ECR_IMAGE):$(VERSION) && \
+	docker push $(ECR_IMAGE):latest
 
 .PHONY: all
 all: base_image image
+
+

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -55,10 +55,10 @@
         },
         "botocore": {
             "hashes": [
-                "sha256:5317aa5cd5f66761d5366c5c80aa8ccd1d798f59a107ccc62437f9d88f5ecab0",
-                "sha256:55d9fb544039add87e8b070eda88f470114f1355df3b16978b90c714cdc7f0a9"
+                "sha256:0f0a2a74a9dc1d53531f559477f329ad087f3b378fc9cf02e67017e475854f8d",
+                "sha256:bc2fa51e05afb944f4f684c7d52a0db165898985d46b2fcb55fb842028fcc7a6"
             ],
-            "version": "==1.12.14"
+            "version": "==1.12.19"
         },
         "bs4": {
             "hashes": [
@@ -400,12 +400,22 @@
             "hashes": [
                 "sha256:21506674d30c009271fe68a242d330c83b1b9d76d62d03d87e1e9528c61beea6",
                 "sha256:3d184aff0756c44fff7de69eb4cd5b5311b6f452d4de28cb08343b3f21993763",
+                "sha256:40c89d3a4e7e6c20db80be638a0a2be103b659ae3b2fc92e25ef1c7ac11be798",
+                "sha256:425e1458d7b893f3ae2fb1bd8344e7bb0beaa114cdc91299c797442638021a17",
                 "sha256:467d364b24cb398f76ad5e90398d71b9325eb4232be9e8a50d6a3b3c7a1c8789",
+                "sha256:4d17483ec4177ee085e690d8d4104de913392250bc50f41fb240c9f378bfb88b",
                 "sha256:57c38470d9f57e37afb460c399eb254e7193ac7fb8042bd09bdc001981a9c74c",
+                "sha256:727aa737a48dd33d6859296f15edb54e85ccdfa5667513f7a50daf362b3df75b",
+                "sha256:7307f7e341f47f057756e1e0e9f5bad85d4cf55a6a8aaafe681e2e5e5dd79446",
                 "sha256:9ada83f4384bbb12dedc152bcdd46a3ac9f5f7720d43ac3ce3e8e8b91d733c10",
                 "sha256:a1daf9c5120f3cc6f2b5fef8e1d2a3fb7bbbb20ed4bfdc25bc8364bc62dcf54b",
+                "sha256:aa1f22d5380d440c78bd9b13dbe697292422277a30eeabcd0ba66b6e37a25ef1",
+                "sha256:b445e2d58d8faa94a9ae863ed10c661e05d7ba6ce00548867a0153e6d927e4a2",
+                "sha256:c2a0ba07228921393b0e28d7306bf8652d5d392cff7eea3f4c0ba599b28f85de",
                 "sha256:e6b77ae84f2b8502d99a7855fa33334a1eb6159de45626905cb3e454c023f339",
                 "sha256:e881ef610ff48aece2f4ee2af03d2db1a146dc7c705561bd6089b2356f61641f",
+                "sha256:ec3cdfb92f714fc02aaf390ee34e7fa636a0478a0976733ac2b39bc23b11a095",
+                "sha256:ef4b9bf3ff28a874a2becda91c281ef4dbc89f9ceacfb1d11040893080a48e18",
                 "sha256:f41037260deaacb875db250021fe883bf536bf6414a4fd25b25059b02e31b120"
             ],
             "markers": "python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*'",
@@ -454,11 +464,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:0a72d8a9f559c006ba153e0c9b4838efd7b656cf1f993747ba7128770d6eb12c",
-                "sha256:95529588ff4e85114a0b0ad8e9cf0131ca47d46b28230e25366c5aba66b1d854"
+                "sha256:7e258ee50338f4e46957f9e09a0f10fb1c2d05493fa901d113a8dafd0790de4e",
+                "sha256:9332147e9af2dcf46cd7ceb14d5acadb6564744ddff1fe8c17f0ce60ece7d9a2"
             ],
             "index": "pypi",
-            "version": "==3.8.1"
+            "version": "==3.8.2"
         },
         "six": {
             "hashes": [


### PR DESCRIPTION
# Description

This PR aims to let us push the new image on AWS using  the makefile. It also add the data folder to the dockerignore file and refresh the current dependencies lock.

## Type of change

Please delete options that are not relevant.

- [x] :sparkles: New feature

# How Has This Been Tested?

Local test