### PR TITLE
Remove files on error and already scraped items

### DIFF
--- a/wsf_scraping/pipelines.py
+++ b/wsf_scraping/pipelines.py
@@ -48,9 +48,9 @@ class WsfScrapingPipeline(object):
         keywords and section based on the section/keywords files provided.
         """
 
-        keep_pdf = self.settings['KEEP_PDF']
+        # keep_pdf = self.settings['KEEP_PDF']
         download_only = self.settings['DOWNLOAD_ONLY']
-        feed = self.settings['FEED_CONFIG']
+        # feed = self.settings['FEED_CONFIG']
         pdf_result_path = os.path.join(
             'results',
             'pdfs',
@@ -75,6 +75,7 @@ class WsfScrapingPipeline(object):
             pdf_file, pdf_text = parse_pdf_document(f)
 
             if not pdf_file:
+                os.remove(item['pdf'])
                 return item
 
             # In some case, the text contains NUL bit that are not allowed in
@@ -101,24 +102,15 @@ class WsfScrapingPipeline(object):
             if keyword_dict:
                 item['keywords'] = keyword_dict
 
-        has_keywords = len(item['keywords'])
+        # has_keywords = len(item['keywords'])
 
         # If we need to keep the pdf, move it, else delete it
-        if keep_pdf or has_keywords:
-            if feed == 'S3':
-                pass
-            else:
-                os.rename(
-                    item['pdf'],
-                    pdf_result_path,
-                )
-        else:
-            try:
-                os.remove(item['pdf'])
-            except FileNotFoundError:
-                self.logger.warning(
-                    "The file couldn't be found, and wasn't deleted."
-                )
+        try:
+            os.remove(item['pdf'])
+        except FileNotFoundError:
+            self.logger.warning(
+                "The file couldn't be found, and wasn't deleted."
+            )
 
         # Remove the path from the value we are storing
         item['pdf'] = os.path.basename(item['pdf'])
@@ -172,6 +164,7 @@ class WsfScrapingPipeline(object):
             self.database.update_full_publication(full_item)
         else:
             # File is already scraped in the database
+            os.remove(item['pdf'])
             raise DropItem(
                 'Item footprint is already in the database'
             )


### PR DESCRIPTION
# Description

This PR aims to improve the scraper performances, in order to let it crawl for prolonged period of time.
In order to achieve it, we delete the PDFs from the temp folder in case of error or if it has already been scraped. Similarly, as saving pdfs locally is no use on a container, we're not saving the PDFs with matching keywords anymore. 
A new implementation saving these to S3 should be added.

Shall fix #102 

## Type of change

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?

Local tests

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If needed, I changed related parts of the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
