### PR TITLE
Convert the item to a dict is we want to scrape again

### DIFF
--- a/wsf_scraping/pipelines.py
+++ b/wsf_scraping/pipelines.py
@@ -163,7 +163,12 @@ class WsfScrapingPipeline(object):
             )
 
         elif db_item.scrape_again:
-            full_item = self.check_keywords(item, spider.name, item['pdf'])
+
+            # Convert the item to dict so we can give it an ID
+            full_item = dict(self.check_keywords(
+                item, spider.name, item['pdf']
+            ))
+
             full_item['id'] = db_item.id
             self.database.update_full_publication(full_item)
         else:


### PR DESCRIPTION
# Description

Convert the item to a dict is we want to scrape again, so we avoid the id error.
Fix for #107 

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?
Local tests
