### PR TITLE
Fix the scraper's JSON results file

### DIFF
--- a/tools/AWSFeedStorage.py
+++ b/tools/AWSFeedStorage.py
@@ -37,7 +37,8 @@ class AWSFeedStorage(BlockingFeedStorage):
 
         last_added = [obj['Key'] for obj in sorted(
             objs,
-            key=lambda obj: obj['LastModified']
+            key=lambda obj: obj['LastModified'],
+            reverse=True
         )][0]
         last_file = self.s3.get_object(
             Bucket=self.s3_bucket,

--- a/tools/dbTools.py
+++ b/tools/dbTools.py
@@ -125,14 +125,14 @@ class DatabaseConnector:
             """
             UPDATE publication
             SET
-                title=%s,
-                url=%s,
-                pdf_name=%s,
-                file_hash=%s,
-                authors=%s,
-                pub_year=%s,
-                pdf_text=%s,
-            WHERE id=%s;
+                title = %s,
+                url = %s,
+                pdf_name = %s,
+                file_hash = %s,
+                authors = %s,
+                pub_year = %s,
+                pdf_text = %s
+            WHERE id = %s;
             """,
             (publication['title'], publication['uri'], publication['pdf'],
              publication['hash'], publication.get('authors'),


### PR DESCRIPTION
# Description

This PR aims to fix #116 . The issue was already referenced in #85 , and caused the scraper to merge the first and new JSON document instead of the last and new one. This caused inconsistent result files.

The issue is still ongoing for WHO, but is caused by te scraper crashing before beeing able to output its results.

Also fix a typo in the SQL query used to update `scrape_again` publications.

Fix #116 
Fix #85 

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can run the tests. Please also list any relevant details for your test configuration:

# Checklist:

- [x] My code follows the style guidelines of this project (pep8 AND pyflakes)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] If needed, I changed related parts of the documentation
~~- [ ] I included tests in my PR~~ (Irrelevant)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] If my PR aims to fix an issue, I referenced it using `#(issue)`
