### PR TITLE
Catch the TypeErrors encountered by the pdf_parser module

### DIFF
--- a/pdf_parser/pdf_parse.py
+++ b/pdf_parser/pdf_parse.py
@@ -30,10 +30,6 @@ def parse_pdf_document(document):
         with open(os.devnull, 'w') as FNULL:
             subprocess.check_call(cmd, stdout=FNULL, stderr=FNULL)
 
-        # Try to get file stats in order to check both its existance
-        # and if it has some content
-        os.stat(parsed_path)
-
     except subprocess.CalledProcessError as e:
         logger.warning(
             "The pdf [%s] could not be converted: %r",
@@ -42,11 +38,22 @@ def parse_pdf_document(document):
         )
         return None, None
 
+    try:
+        # Try to get file stats in order to check both its existance
+        # and if it has some content
+        st = os.stat(parsed_path)
+
     except OSError as e:
         if e.errno != errno.ENOENT:
             raise
 
         logger.warning('Error trying to open the parsed file: %s', e)
+        return None, None
+
+    if st.st_size == 0:
+        logger.warning(
+            'Error trying to open the parsed file: The file is empty'
+        )
         return None, None
 
     with open(parsed_path, 'rb') as html_file:

--- a/pdf_parser/pdf_parse.py
+++ b/pdf_parser/pdf_parse.py
@@ -18,12 +18,12 @@ def parse_pdf_document(document):
     parsed_path = document.name.replace('.pdf', '.xml')
     # Run pdftohtml on the document, and output an xml formated document
     cmd = [
-            'pdftohtml',
-            '-i',
-            '-xml',
-            document.name,
-            parsed_path
-            ]
+        'pdftohtml',
+        '-i',
+        '-xml',
+        document.name,
+        parsed_path
+    ]
 
     try:
         with open(os.devnull, 'w') as FNULL:
@@ -42,6 +42,10 @@ def parse_pdf_document(document):
 
     except FileNotFoundError:
         return None, None
+
+    except TypeError:
+        logger.warning("Couldn't parse the converted file as it appears"
+                       " to be empty")
 
     text = soup.text
     file_pages = []


### PR DESCRIPTION
# Description

The pdf parser module sometimes struggles to parse a PDF, either because
it is password locked, encrypted, too big, malformed, etc.

If an error is encountered, Beautiful soup tries to load a
malformed/empty file, which leads to a NoneType has no iterable or TypeError.

To fix this issue, we're catching the exception and log it as a warning.

This should Fix #125 and Fix #126

## Type of change

Please delete options that are not relevant.

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?
Local tests
