### PR TITLE
Remove the pdf_text field from the scraper

### DIFF
--- a/pdf_parser/pdf_parse.py
+++ b/pdf_parser/pdf_parse.py
@@ -60,7 +60,6 @@ def parse_pdf_document(document):
     with open(parsed_path, 'rb') as html_file:
         soup = bs(html_file.read(), 'html.parser')
 
-    text = soup.text
     file_pages = []
     pages = soup.find_all('page')
 
@@ -97,7 +96,7 @@ def parse_pdf_document(document):
     pdf_file = PdfFile(file_pages)
     html_file.close()
     os.remove(parsed_path)
-    return pdf_file, text
+    return pdf_file
 
 
 def grab_section(pdf_file, keyword):

--- a/tests/test_db_tools.py
+++ b/tests/test_db_tools.py
@@ -17,7 +17,6 @@ class TestDBTools(unittest.TestCase):
             'hash': '0' * 32,
             'authors': 'John Doe, Jane Doe',
             'year': '1999',
-            'text': 'Very long sentence' * 300,
         }
         sections = {'foo': 'bar' * 32}
         keywords = {'bar': 'foo' * 32}

--- a/tests/test_pdf_objects.py
+++ b/tests/test_pdf_objects.py
@@ -58,7 +58,7 @@ class TestPdfObjects(unittest.TestCase):
 
     def setUp(self):
         self.test_file = open(TEST_PDF, 'rb')
-        self.pdf_file_object, self.text = parse_pdf_document(self.test_file)
+        self.pdf_file_object = parse_pdf_document(self.test_file)
 
     def tearDown(self):
         self.test_file.close()

--- a/tests/test_pdf_parser_tools.py
+++ b/tests/test_pdf_parser_tools.py
@@ -9,7 +9,7 @@ class TestTools(unittest.TestCase):
 
     def setUp(self):
         self.test_file = open(TEST_PDF, 'rb')
-        self.pdf_file_object, self.text = parse_pdf_document(self.test_file)
+        self.pdf_file_object = parse_pdf_document(self.test_file)
 
     def tearDown(self):
         self.test_file.close()

--- a/tools/dbTools.py
+++ b/tools/dbTools.py
@@ -108,15 +108,14 @@ class DatabaseConnector:
         self._execute(
             """
             INSERT INTO publication(title, url, pdf_name, file_hash,
-                             authors, pub_year, pdf_text,
+                             authors, pub_year,
                              id_provider, datetime_creation)
-            VALUES(%s, %s, %s, %s, %s, %s, %s, %s, %s)
+            VALUES(%s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING id;
             """,
             (publication['title'], publication['uri'], publication['pdf'],
              publication['hash'], publication.get('authors'),
-             publication.get('year'), publication['text'], id_provider,
-             datetime.now(),)
+             publication.get('year'), id_provider, datetime.now(),)
         )
         return self.cursor.fetchone().id
 
@@ -131,14 +130,12 @@ class DatabaseConnector:
                 file_hash = %s,
                 authors = %s,
                 pub_year = %s,
-                pdf_text = %s,
                 scrape_again = %s
             WHERE id = %s;
             """,
             (publication['title'], publication['uri'], publication['pdf'],
              publication['hash'], publication.get('authors'),
-             publication.get('year'), publication['text'], False,
-             publication['id'],)
+             publication.get('year'), False, publication['id'],)
         )
 
     def insert_joints_and_text(self, table, items, id_publication):

--- a/wsf_scraping/pipelines.py
+++ b/wsf_scraping/pipelines.py
@@ -56,16 +56,12 @@ class WsfScrapingPipeline(object):
                 item['pdf']
             )
 
-            pdf_file, pdf_text = parse_pdf_document(f)
+            pdf_file = parse_pdf_document(f)
 
             # If the PDF couldn't be converted, still remove the pdf file
             if not pdf_file:
                 os.remove(item['pdf'])
                 return item
-
-            # In some case, the text contains NUL bit that are not allowed in
-            # PSQL. We just remove them.
-            item['text'] = pdf_text.replace('\0', '')
 
             for keyword in self.section_keywords:
                 # Fetch references or other keyworded list


### PR DESCRIPTION
# Description

The pdf_text field takes too much space in the database. This PR aims to remove it from the scraper.

## Type of change

Please delete options that are not relevant.

- [x] :fire: Breaking change

# How Has This Been Tested?

Local tests, unit tests
