### PR TITLE
Fix Sentry spamming us with Http Errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 IMAGE := uk.ac.wellcome/web-scraper
 ECR_IMAGE := 160358319781.dkr.ecr.eu-west-1.amazonaws.com/$(IMAGE)
-VERSION := 2019.1.0
+VERSION := 2019.1.1
 
 .PHONY: base_image
 base_image:

--- a/wsf_scraping/spiders/base_spider.py
+++ b/wsf_scraping/spiders/base_spider.py
@@ -16,15 +16,16 @@ class BaseSpider(scrapy.Spider):
 
         if failure.check(HttpError):
             response = failure.value.response
-            self.logger.error('HttpError on %s', response.url)
+            self.logger.warning('HttpError (%s) on %s',
+                                response.url, response.status)
 
         elif failure.check(DNSLookupError):
             request = failure.request
-            self.logger.error('DNSLookupError on %s', request.url)
+            self.logger.warning('DNSLookupError on %s', request.url)
 
         elif failure.check(TimeoutError):
             request = failure.request
-            self.logger.error('TimeoutError on %s', request.url)
+            self.logger.warning('TimeoutError on %s', request.url)
 
         else:
             self.logger.error(repr(failure))


### PR DESCRIPTION
# Description

Scraping the web is sometimes tricky. On most of our scrape, we
encounter at least a few Http Error (timeouts mostly).

The initial way to catch these errors logged them as errors, leading
them to get caught by Sentry. This Commit changes this behaviour by
changing the log type to warning.

This is possible as we know these errors are going to happen, and as
they don't give us much valuable reporting.

They should be monitored to have clean metrics, though.

Fix #127 

## Type of change

- [x] :bug: Bug fix (Add `Fix #(issue)` to your PR)

# How Has This Been Tested?

Local tests using a local Python Http server returning http errors.